### PR TITLE
Sessions // add infinite scroll

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -7,6 +7,9 @@ export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
+  customEvents = {
+    scroll: "scroll",
+  }
 }
 
 loadInitializers(App, config.modulePrefix);

--- a/app/components/infinite-list.hbs
+++ b/app/components/infinite-list.hbs
@@ -1,0 +1,12 @@
+<div class="au-u-flex au-u-flex--column" style="overflow-y: scroll;" {{on "scroll" this.scroll}}>
+    <section class="au-u-flex au-u-flex--column">
+        {{ yield }}
+    </section>
+    <div class="au-u-flex au-u-flex--center au-u-padding">
+        {{#if @isLoading}}
+            <AuLoader />
+        {{else}}
+            <AuButton {{action "loadMore"}}>Laad meer</AuButton>
+        {{/if}}
+    </div>
+</div>

--- a/app/components/infinite-list.ts
+++ b/app/components/infinite-list.ts
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { throttle } from '@ember/runloop';
+
+interface ArgsInterface {
+    loadMore: () => void;
+    isLoading: boolean;
+}
+
+export default class InfiniteList extends Component<ArgsInterface> {
+    @action
+    scroll(event: any) {
+        throttle(this, this._onScroll, event, 500, false);
+    }
+
+    _onScroll(event: Event) {
+        const { scrollTop, scrollHeight, clientHeight } = event.target as HTMLElement;
+        const scrollTopMax = scrollHeight - clientHeight;
+        const scrollPercentage = scrollTop / scrollTopMax;
+
+        // trigger loadMore when >80% is scrolled
+        if (scrollPercentage > .8) {
+            this.loadMore();
+        }
+    }
+
+    @action
+    loadMore() {
+        this.args.loadMore();
+    }
+}

--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -1,0 +1,29 @@
+import Controller from "@ember/controller";
+import Store from "@ember-data/store";
+import { action } from "@ember/object";
+import { ModelFrom } from '../../lib/type-utils';
+import SessionIndexRoute from '../../routes/sessions/index';
+import { tracked } from "@glimmer/tracking";
+import { service } from "@ember/service";
+
+export default class SessionsIndexController extends Controller {
+    declare model: ModelFrom<SessionIndexRoute>;
+    @service declare store: Store;
+    @tracked isLoadingMore = false;
+
+    @action
+    async loadMore() {
+        //todo add max page guard
+        if (this.model && !this.isLoadingMore) {
+            this.isLoadingMore = true;
+            const nextPage = this.model.currentPage + 1;
+
+            const sessions = await this.store.query("session", this.model.getQuery(nextPage));
+            const concatenateSessions = this.model.sessions.concat(sessions.toArray());
+            this.model.sessions.setObjects(concatenateSessions);
+
+            this.model.currentPage = nextPage;
+            this.isLoadingMore = false;
+        }
+    }
+}

--- a/app/routes/sessions/index.ts
+++ b/app/routes/sessions/index.ts
@@ -2,25 +2,41 @@ import Store from "@ember-data/store";
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
+const getQuery = (page: number) => ({
+    // exclude sessions without governing body and administrative unit
+    //todo investigate why filtering is not working
+    filter: {
+        ":has:governing-body": true,
+        "governing-body": {
+            ":has:administrative-unit": true,
+        },
+    },
+    include: [
+        'governing-body.administrative-unit',
+        'agenda-items',
+    ].join(','),
+    page: {
+        number: page
+    }
+});
+    
+
 export default class SessionsIndexRoute extends Route {
     @service declare store: Store;
 
     async model() {
-        const sessions = await this.store.query("session", {
-            // exclude sessions without governing body and administrative unit
-            //todo investigate why filtering is not working
-            filter: {
-                ":has:governing-body": true,
-                "governing-body": {
-                    ":has:administrative-unit": true,
-                },
-            },
-            include: [
-                'governing-body.administrative-unit',
-                'agenda-items',
-            ].join(',')
-        });
+        const model:any = this.modelFor('sessions.index');
+        if (model?.sessions?.toArray().length > 0) {
+            return model;
+        } 
 
-        return sessions;
+        const currentPage = 0;
+        const sessions = await this.store.query("session", getQuery(currentPage));
+
+        return {
+            sessions: sessions.toArray(),
+            currentPage: currentPage,
+            getQuery,
+        };
     }
 }

--- a/app/routes/sessions/session.ts
+++ b/app/routes/sessions/session.ts
@@ -9,7 +9,7 @@ export default class SessionRoute extends Route {
 
   async model({ session_id }: { session_id: string }) {
     // @ts-ignore
-    const sessionFromParent: undefined | SessionModel = this.modelFor('sessions.index')?.find((session: any) => session.id === session_id);
+    const sessionFromParent: undefined | SessionModel = this.modelFor('sessions.index')?.sessions?.find((session: any) => session.id === session_id);
     const session: SessionModel = sessionFromParent ?? await this.store.findRecord("session", session_id, {
       include: [
         'governing-body.administrative-unit',

--- a/app/templates/sessions/index.hbs
+++ b/app/templates/sessions/index.hbs
@@ -1,22 +1,20 @@
 {{page-title "Zittingen"}}
 
-<div class="au-u-flex detail-container" style="overflow-y: scroll;">
-    <section style="height: fit-content; width: 100%;" class="au-u-flex au-u-flex--column">
-        {{#each @model as |session|}}
-            <LinkTo @route="sessions.session" @model={{session.id}}>
-                <AuCard @size="small" class="card-hover au-u-padding-bottom au-u-padding" as |c|>
-                    <c.header>
-                        <AuHeading @level="1" @skin="3">
-                            <AuLink style="text-overflow: ellipsis; max-height: 50%;">
-                                {{session.name}} {{session.dateRange}}
-                            </AuLink>
-                        </AuHeading>
-                    </c.header>
-                    <c.footer>
-                        {{session.municipality}} - {{session.agendaItemCount}}
-                    </c.footer>
-                </AuCard>
-            </LinkTo>
-        {{/each}}
-    </section>
-</div>
+<InfiniteList @loadMore={{action "loadMore"}} @isLoading={{this.isLoadingMore}}>
+    {{#each @model.sessions as |session|}}
+        <LinkTo @route="sessions.session" @model={{session.id}}>
+            <AuCard @size="small" class="card-hover au-u-padding" as |c|>
+                <c.header>
+                    <AuHeading @level="1" @skin="3">
+                        <AuLink>
+                            {{session.name}} {{session.dateRange}}
+                        </AuLink>
+                    </AuHeading>
+                </c.header>
+                <c.footer>
+                    {{session.municipality}} - {{session.agendaItemCount}}
+                </c.footer>
+            </AuCard>
+        </LinkTo>
+    {{/each}}
+</InfiniteList>


### PR DESCRIPTION
The following changes have been made in order to load more data when the user reaches the bottom of the session list in the `sessions/index` route:
- add `scroll` event in app config `customEvents` to be able to listen the event in components. 
- create a new component (InfiniteList)
   - it's a container that listens for the `scroll` event on itself and dispatches `loadMore` when the scroll reaches over 80%.
- add `sessions/index` controller to catches `loadMore`, then load and add extra sessions on model.
- prevent model reset in `sessions` route when we navigate through the app.
- add `currentPage` in sessions model


[Screencast from 15-06-23 10:12:37.webm](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/284f7bbe-11e7-4a6a-a143-2b23cfd6b299)