### PR TITLE
Sessions date more consistent

### DIFF
--- a/app/components/decision-card.hbs
+++ b/app/components/decision-card.hbs
@@ -2,7 +2,7 @@
 
   class="au-u-margin-bottom-small component-decision-card"
   @route="detail"
-  @model={{this.item.id}}
+  @model={{@item.id}}
 >
   <AuCard
     @size="small"
@@ -17,32 +17,28 @@
           {{! template-lint-disable no-inline-styles}}
           style="text-overflow: ellipsis; max-height: 50%;"
           @route="detail"
-          @model={{this.item.id}}
+          @model={{@item.id}}
         >
-          {{this.item.title}}
+          {{@item.title}}
         </AuLink>
       </AuHeading>
     </c.header>
     <c.content>
-      {{#if this.item.description}}
-        <p class="truncate">{{this.item.description}}</p>
+      {{#if @item.description}}
+        <p class="truncate">{{@item.description}}</p>
       {{/if}}
     </c.content>
     <c.footer>
-      {{#if this.dateRange}}
-        {{this.dateRange}}
-      {{else}}
-        Geen Datum
-      {{/if}}
+      {{@item.session.dateFormatted}}
       -
-      {{#if this.item.session.governingBody.name}}
-        {{this.item.session.governingBody.name}}
+      {{#if @item.session.governingBody.name}}
+        {{@item.session.governingBody.name}}
       {{else}}
         Geen Bestuurorgaan
       {{/if}}
       -
-      {{#if this.item.session.governingBody.administrativeUnit.name}}
-        {{this.item.session.governingBody.administrativeUnit.name}}
+      {{#if @item.session.governingBody.administrativeUnit.name}}
+        {{@item.session.governingBody.administrativeUnit.name}}
       {{else}}
         Geen Bestuurseenheid
       {{/if}}

--- a/app/components/decision-card.ts
+++ b/app/components/decision-card.ts
@@ -1,36 +1,8 @@
 import Component from '@glimmer/component';
-import { format } from 'date-fns';
 
 interface ArgsInterface {
   item: any;
-  endDate: any;
-  startDate: any;
 }
 
 export default class DecisionCard extends Component<ArgsInterface> {
-  get item() {
-    return this.args.item ? this.args.item : null;
-  }
-
-  get startDate() {
-    return this.args.startDate
-      ? format(this.args.startDate, 'dd/MM/yyyy')
-      : null;
-  }
-
-  get endDate() {
-    return this.args.endDate ? format(this.args.endDate, 'dd/MM/yyyy') : null;
-  }
-
-  get dateRange() {
-    if (!this.endDate && !this.startDate) return undefined;
-    if (!this.endDate) return this.startDate;
-    if (!this.startDate) return this.endDate;
-
-    if (this.startDate != this.endDate) {
-      return this.startDate + ' tot ' + this.endDate;
-    } else {
-      return this.endDate;
-    }
-  }
 }

--- a/app/components/decision-card.ts
+++ b/app/components/decision-card.ts
@@ -1,8 +1,0 @@
-import Component from '@glimmer/component';
-
-interface ArgsInterface {
-  item: any;
-}
-
-export default class DecisionCard extends Component<ArgsInterface> {
-}

--- a/app/models/session.ts
+++ b/app/models/session.ts
@@ -41,14 +41,14 @@ export default class SessionModel extends Model {
   }
 
   get dateFormatted() {
-    if(!!this.startedAt || !!this.endedAt) {
+    if (this.startedAt || this.endedAt) {
       return getFormattedDateRange(this.startedAt, this.endedAt);
     }
-    if(!!this.plannedStart) {
-      return "Gepland op " + getFormattedDate(this.plannedStart);
+    if (this.plannedStart) {
+      return 'Gepland op ' + getFormattedDate(this.plannedStart);
     }
 
-    return "Geen Datum";
+    return 'Geen Datum';
   }
 
   get agendaItemCount() {

--- a/app/models/session.ts
+++ b/app/models/session.ts
@@ -45,7 +45,7 @@ export default class SessionModel extends Model {
       return getFormattedDateRange(this.startedAt, this.endedAt);
     }
     if(!!this.plannedStart) {
-      return getFormattedDate(this.plannedStart);
+      return "Gepland op " + getFormattedDate(this.plannedStart);
     }
 
     return "Geen Datum";

--- a/app/models/session.ts
+++ b/app/models/session.ts
@@ -5,10 +5,12 @@ import Model, {
   type AsyncHasMany,
 } from '@ember-data/model';
 import { getFormattedDateRange } from 'frontend-burgernabije-besluitendatabank/utils/get-formatted-date-range';
+import { getFormattedDate } from 'frontend-burgernabije-besluitendatabank/utils/get-formatted-date';
 import AgendaItemModel from './agenda-item';
 import GoverningBodyModel from './governing-body';
 
 export default class SessionModel extends Model {
+  @attr('date') declare plannedStart?: Date;
   @attr('date') declare startedAt?: Date;
   @attr('date') declare endedAt?: Date;
 
@@ -38,8 +40,15 @@ export default class SessionModel extends Model {
     return !!this.governingBody?.administrativeUnit;
   }
 
-  get dateRange() {
-    return getFormattedDateRange(this.startedAt, this.endedAt);
+  get dateFormatted() {
+    if(!!this.startedAt || !!this.endedAt) {
+      return getFormattedDateRange(this.startedAt, this.endedAt);
+    }
+    if(!!this.plannedStart) {
+      return getFormattedDate(this.plannedStart);
+    }
+
+    return "Geen Datum";
   }
 
   get agendaItemCount() {

--- a/app/routes/agenda-items.ts
+++ b/app/routes/agenda-items.ts
@@ -31,11 +31,11 @@ const getQuery = ({
     'session.governing-body.administrative-unit',
     'session.governing-body.administrative-unit.location',
   ].join(','),
-  sort: '-session.started-at',
+  sort: '-session.planned-start',
   filter: {
     session: {
-      ':gt:started-at': plannedStartMin ? plannedStartMin : undefined,
-      ':lt:ended-at': plannedStartMax ? plannedStartMax : undefined,
+      ':gt:planned-start': plannedStartMin ? plannedStartMin : undefined,
+      ':lt:planned-start': plannedStartMax ? plannedStartMax : undefined,
       ':has:governing-body': true,
       'governing-body': {
         ':has:administrative-unit': true,
@@ -68,8 +68,8 @@ interface AgendaItemsRequestInterface {
   filter?: {
     ':or:'?: {};
     session?: {
-      ':gt:started-at'?: string | undefined;
-      ':lt:ended-at'?: string | undefined;
+      ':gt:planned-start'?: string | undefined;
+      ':lt:planned-start'?: string | undefined;
       ':has:governing-body'?: boolean;
       'governing-body'?: {
         ':has:administrative-unit'?: boolean;

--- a/app/routes/map.ts
+++ b/app/routes/map.ts
@@ -12,7 +12,7 @@ interface AgendaItemsRequestInterface {
   filter?: {
     ':has:session'?: boolean;
     session?: {
-      ':gt:started-at'?: string;
+      ':gt:planned-start'?: string;
 
       ':has:governing-body'?: boolean;
       'governing-body'?: {
@@ -44,7 +44,7 @@ export default class MapRoute extends Route {
       filter: {
         ':has:session': true,
         session: {
-          ':gt:started-at': new Date(
+          ':gt:planned-start': new Date(
             new Date().setMonth(new Date().getMonth() - 3)
           )
             .toISOString()

--- a/app/routes/sessions/index.ts
+++ b/app/routes/sessions/index.ts
@@ -28,7 +28,7 @@ const getQuery = (
     ':lt:planned-start': plannedStartMax ? plannedStartMax : undefined,
   },
   include: ['governing-body.administrative-unit', 'agenda-items'].join(','),
-  sort: '-started-at',
+  sort: '-planned-start',
   page: {
     number: page,
   },

--- a/app/templates/detail.hbs
+++ b/app/templates/detail.hbs
@@ -174,13 +174,11 @@
         class="au-c-card au-u-margin-large au-u-flex"
         as |c|
       >
-      {{#if this.model.agendaItem.session.dateRange}}
         <c.header>
           <h2 class="au-u-h3">
-              Meer agenda op {{this.model.agendaItem.session.dateRange}}
+              Meer agenda op {{this.model.agendaItem.session.dateFormatted}}
           </h2>
         </c.header>
-      {{/if}}
         <c.content class="au-u-flex au-u-flex--column">
           {{#if this.model.agendaItemOnSameSession}}
             {{#each this.model.agendaItemOnSameSession as |agendaItem|}}

--- a/app/templates/detail.hbs
+++ b/app/templates/detail.hbs
@@ -29,12 +29,7 @@
           class="au-u-flex au-u-muted au-u-margin-top-tiny au-u-u-flex--vertical-center"
         >
           <AuIcon class="au-u-margin-right-small" @size="large" @icon="check" />
-          <p>
-            {{#if this.model.agendaItem.session.dateRange}}
-              {{ this.model.agendaItem.session.dateRange}}
-            {{else}}
-              Geen Datum
-            {{/if}}</p>
+          <p>{{ this.model.agendaItem.session.dateFormatted}}</p>
         </section>
         <section
           class="au-u-flex au-u-muted au-u-margin-top-tiny au-u-u-flex--vertical-center"

--- a/app/templates/detail.hbs
+++ b/app/templates/detail.hbs
@@ -29,7 +29,7 @@
           class="au-u-flex au-u-muted au-u-margin-top-tiny au-u-u-flex--vertical-center"
         >
           <AuIcon class="au-u-margin-right-small" @size="large" @icon="check" />
-          <p>{{ this.model.agendaItem.session.dateFormatted}}</p>
+          <p>{{this.model.agendaItem.session.dateFormatted}}</p>
         </section>
         <section
           class="au-u-flex au-u-muted au-u-margin-top-tiny au-u-u-flex--vertical-center"

--- a/app/templates/sessions/index.hbs
+++ b/app/templates/sessions/index.hbs
@@ -54,7 +54,7 @@
                 <AuHeading @level="1" @skin="3">
                   <AuLink @route="sessions.session" @model={{session.id}}>
                     {{session.name}}
-                    {{session.dateRange}}
+                    {{session.dateFormatted}}
                   </AuLink>
                 </AuHeading>
               </c.header>

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -4,7 +4,7 @@
   <section class="au-o-box">
     <AuHeading @level="1">
       {{this.model.name}}
-      {{this.model.dateRange}}
+      {{this.model.dateFormatted}}
     </AuHeading>
   </section>
   <section


### PR DESCRIPTION
Improve Session date consistency by using `session.planned-start` on filtering and sorting everywhere. 