### PR TITLE
Fix agenda item on same session in detail page

### DIFF
--- a/app/controllers/sessions/session.ts
+++ b/app/controllers/sessions/session.ts
@@ -2,14 +2,13 @@ import Controller from "@ember/controller";
 import {computed} from "@ember/object";
 import { ModelFrom } from '../../lib/type-utils';
 import SessionSessionRoute from '../../routes/sessions/session';
+import { sortObjectsByTitle } from "frontend-burgernabije-besluitendatabank/utils/array-utils";
 
 export default class SessionsSessionController extends Controller {
     declare model: ModelFrom<SessionSessionRoute>;
 
     @computed('model.agendaItems')
     get agendaItemsSorted() {
-        return this.model.agendaItems.toArray().sort((a, b) => {
-            return a.title.localeCompare(b.title, undefined, { numeric: true });
-        });
+        return this.model.agendaItems.toArray().sort(sortObjectsByTitle);
     }
 }

--- a/app/templates/detail.hbs
+++ b/app/templates/detail.hbs
@@ -182,12 +182,11 @@
       {{#if this.model.agendaItem.session.dateRange}}
         <c.header>
           <h2 class="au-u-h3">
-              Volledige agenda van {{this.model.agendaItem.session.dateRange}}
+              Meer agenda op {{this.model.agendaItem.session.dateRange}}
           </h2>
         </c.header>
       {{/if}}
         <c.content class="au-u-flex au-u-flex--column">
-
           {{#if this.model.agendaItemOnSameSession}}
             {{#each this.model.agendaItemOnSameSession as |agendaItem|}}
               {{! if the agendaItem.id is equal to the current agendaItem then display "Huidige agendapunt" }}
@@ -202,7 +201,11 @@
             {{/each}}
           {{/if}}
         </c.content>
-
+        <c.footer>
+          <AuLink @route="sessions.session" @model={{this.model.agendaItem.session.id}}>
+            Bekijk de volledige agenda
+          </AuLink>
+        </c.footer>
       </AuCard>
     {{/if}}
   </article>

--- a/app/utils/array-utils.ts
+++ b/app/utils/array-utils.ts
@@ -1,0 +1,3 @@
+interface WithTitle { title: string }
+
+export const sortObjectsByTitle = (a: WithTitle, b: WithTitle) => a.title.localeCompare(b.title, undefined, { numeric: true });

--- a/tests/unit/utils/array-utils-test.js
+++ b/tests/unit/utils/array-utils-test.js
@@ -1,0 +1,30 @@
+import { sortObjectsByTitle } from 'frontend-burgernabije-besluitendatabank/utils/array-utils';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | array-utils', function () {
+
+  module('sortObjectsByTitle', function () {
+
+    test('it sorts the array of objects based on the title property', function (assert) {
+      const source = [
+        { title: "10. Apple" },
+        { title: "Banana 10" },
+        { title: "Orange" },
+        { title: "3. Apple" },
+        { title: "Banana 2" },
+      ];
+
+      const sorted = [
+        { title: "3. Apple" },
+        { title: "10. Apple" },
+        { title: "Banana 2" },
+        { title: "Banana 10" },
+        { title: "Orange" },
+      ];
+
+      const result = source.sort(sortObjectsByTitle);
+
+      assert.deepEqual(result, sorted);
+    });
+  });
+});


### PR DESCRIPTION
This PR contains the following modifications: 
- [Extract sortObjectsByTitle in array-utils](https://github.com/lblod/frontend-burgernabije-besluitendatabank/commit/ebb2056e6aab918e73227f8ed2250bf341aa5698) in order to use it in detail page. 
- Fix the way of `agendaItemOnSameSession` is loaded in detail page (use session id instead of date). 
- Add a link to redirect all agenda-items related on the same session. 

## Before

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/fc20eac8-fd3b-456c-942d-9bdbea3073fc)


## After: 

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/c4e6813c-773c-4bf9-9b10-34f3bc3ca5fd)
