### PR TITLE
Fix detail async data display

### DIFF
--- a/app/models/administrative-unit.ts
+++ b/app/models/administrative-unit.ts
@@ -22,8 +22,15 @@ export default class AdministrativeUnitModel extends Model {
   })
   declare classification: AsyncBelongsTo<AdministrativeUnitClasssificationCodeModel>;
 
-  @belongsTo('location', { async: false, inverse: null })
-  declare location: LocationModel;
+  @belongsTo('location', { async: true, inverse: null })
+  declare location: AsyncBelongsTo<LocationModel>;
+
+  get locationValue() {
+    // cast this because of https://github.com/typed-ember/ember-cli-typescript/issues/1416
+    return (this as AdministrativeUnitModel)
+      .belongsTo('location')
+      ?.value() as LocationModel | null;
+  }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/governing-body.ts
+++ b/app/models/governing-body.ts
@@ -3,6 +3,7 @@ import Model, {
   belongsTo,
   hasMany,
   AsyncHasMany,
+  AsyncBelongsTo,
 } from '@ember-data/model';
 import SessionModel from './session';
 import AdministrativeUnitModel from './administrative-unit';
@@ -26,25 +27,39 @@ export default class GoverningBodyModel extends Model {
   @attr('string', { defaultValue: 'Ontbrekende naam' }) declare name: string;
 
   @belongsTo('administrative-unit', {
-    async: false,
+    async: true,
     inverse: 'governingBodies',
   })
-  declare administrativeUnit: AdministrativeUnitModel;
+  declare administrativeUnit: AsyncBelongsTo<AdministrativeUnitModel>;
+
+  get administrativeUnitValue() {
+    // cast this because of https://github.com/typed-ember/ember-cli-typescript/issues/1416
+    return (this as GoverningBodyModel)
+      .belongsTo('administrativeUnit')
+      ?.value() as AdministrativeUnitModel | null;
+  }
 
   @hasMany('session', { async: true, inverse: 'governingBody' })
   declare sessions: AsyncHasMany<SessionModel>;
 
   @belongsTo('governing-body', {
-    async: false,
+    async: true,
     inverse: 'hasTimeSpecializations',
   })
-  declare isTimeSpecializationOf: GoverningBodyModel;
+  declare isTimeSpecializationOf: AsyncBelongsTo<GoverningBodyModel>;
 
   @hasMany('governing-body', {
     async: true,
     inverse: 'isTimeSpecializationOf',
   })
   declare hasTimeSpecializations: AsyncHasMany<GoverningBodyModel>;
+
+  get isTimeSpecializationOfValue() {
+    // cast this because of https://github.com/typed-ember/ember-cli-typescript/issues/1416
+    return (this as GoverningBodyModel)
+      .belongsTo('isTimeSpecializationOf')
+      ?.value() as GoverningBodyModel | null;
+  }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/routes/detail.ts
+++ b/app/routes/detail.ts
@@ -10,12 +10,6 @@ interface DetailParams {
   id: string;
 }
 
-interface FormattedTableVote {
-  proponent: MandataryModel | null;
-  opponent: MandataryModel | null;
-  abstainer: MandataryModel | null;
-}
-
 export default class DetailRoute extends Route {
   @service declare store: Store;
   @service declare keywordStore: KeywordStoreService;

--- a/app/routes/detail.ts
+++ b/app/routes/detail.ts
@@ -15,9 +15,25 @@ export default class DetailRoute extends Route {
   @service declare keywordStore: KeywordStoreService;
 
   async model(params: DetailParams) {
-    const agendaItem: AgendaItemModel = await this.store.findRecord(
-      'agenda-item',
-      params.id
+    const agendaItem = await this.store.findRecord('agenda-item', params.id);
+
+    // wait until sessions are loaded
+    const sessions = await agendaItem.sessions;
+    // SessionModel expects the following to be loaded:
+    // - governingBody.isTimeSpecializationOf.administrativeUnit.location
+    // - governingBody.administrativeUnit.location
+    // to resolve municipality & governingBody name
+    await Promise.all(
+      sessions?.map(async (session) => {
+        const governingBody = await session.governingBody;
+        const isTimeSpecializationOf =
+          await governingBody?.isTimeSpecializationOf;
+        let administrativeUnit =
+          await isTimeSpecializationOf?.administrativeUnit;
+        await administrativeUnit?.location;
+        administrativeUnit = await governingBody?.administrativeUnit;
+        await administrativeUnit?.location;
+      }) || []
     );
 
     const sessionId = agendaItem.session?.id;


### PR DESCRIPTION
This PR fix missing data loading in detail page. 

## Context

In order to fix detail page render when resolution value has Literal type, include parameter was removed from queries in detail page. 
https://github.com/lblod/frontend-burgernabije-besluitendatabank/pull/68/files#diff-071a3020b5ae0cb90e61e65c431b8d30c2ea445f40568cdbce2bd769a84bf6faL19-L30

As a side effect, all relationships expected to be sync are async now and not display correctly. 

## Before

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/63b126f8-81bd-4a68-8e38-af1501d2c9d8)

## After

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/eac107df-8855-4073-8d61-45283689831b)

