### PR TITLE
Fix display all voters

### DIFF
--- a/app/adapters/vote.ts
+++ b/app/adapters/vote.ts
@@ -1,0 +1,23 @@
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import Store, { Snapshot } from '@ember-data/store';
+
+export default class VoteAdapter extends JSONAPIAdapter {
+  findHasMany(
+    store: Store,
+    snapshot: Snapshot,
+    url: string,
+    relationship: { key: string }
+  ) {
+    // add page size 100 when relationship is voters
+    if (
+      ['hasProponents', 'hasOpponents', 'hasAbstainers'].includes(
+        relationship?.key
+      )
+    ) {
+      const separator = url.includes('?') ? '&' : '?';
+      url = `${url}${separator}page[size]=100`;
+    }
+
+    return super.findHasMany(store, snapshot, url, relationship);
+  }
+}

--- a/app/components/infinite-list.ts
+++ b/app/components/infinite-list.ts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { throttle } from '@ember/runloop';
-import { tracked } from '@glimmer/tracking';
 
 interface ArgsInterface {
   loadMore: () => void;

--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -7,7 +7,6 @@ import SessionIndexRoute from '../../routes/sessions/index';
 import { ModelFrom } from '../../lib/type-utils';
 import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
 import Session from 'frontend-burgernabije-besluitendatabank/models/session';
-import { seperator } from 'frontend-burgernabije-besluitendatabank/helpers/constants';
 
 export default class SessionsIndexController extends Controller {
   @service declare store: Store;


### PR DESCRIPTION
Display all voters in Detail page "Wie stemde?" table. 

## Context

In order to fix detail page render when resolution value has Literal type, include parameter was removed from queries in detail page. 
https://github.com/lblod/frontend-burgernabije-besluitendatabank/pull/68/files#diff-071a3020b5ae0cb90e61e65c431b8d30c2ea445f40568cdbce2bd769a84bf6faL19-L30

Now all relations are loaded asynchronously.

As a side effect, default pagination (20) is applied on voters (`hasProponents', 'hasOpponents', 'hasAbstainers`). There is no pagination in include data. 

## Proposale

Increase page size to 100 on vote `hasProponents', 'hasOpponents', 'hasAbstainers` relationships. 

## Before

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/a180e935-caee-435f-b2fc-14e8f6b33119)


## After 

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/41ed7668-46c2-4b8d-9603-11b893997ecc)
