### PR TITLE
Fix an issue in the text filter component

### DIFF
--- a/app/components/filters/text-filter.hbs
+++ b/app/components/filters/text-filter.hbs
@@ -12,7 +12,7 @@
       <input
         {{!template-lint-disable no-duplicate-id}}
         id={{@id}}
-        value={{@value}}
+        value={{this.value}}
         class="au-c-input au-c-input--block {{@inputClass}}"
         disabled={{@disabled}}
         {{on "input" this.handleChange}}


### PR DESCRIPTION
We weren't using the `@localCopy`d value in the template so the internal state was getting out of sync resulting in a strange bug.

Because we now use `this.value` in the template, it reruns when needed so the state is always in sync.