### PR TITLE
Only enable plausible when the config is provided

### DIFF
--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -9,6 +9,10 @@ declare const config: {
   locationType: 'history' | 'none';
   rootURL: string;
   APP: Record<string, unknown>;
+  plausible: {
+    apiHost: string;
+    domain: string;
+  };
 };
 
 export default config;

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -1,0 +1,23 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import type PlausibleService from 'ember-plausible/services/plausible';
+import config from 'frontend-burgernabije-besluitendatabank/config/environment';
+
+export default class ApplicationRoute extends Route {
+  @service declare plausible: PlausibleService;
+
+  beforeModel(): void {
+    this.startAnalytics();
+  }
+
+  startAnalytics(): void {
+    const { domain, apiHost } = config.plausible;
+
+    if (!domain.startsWith('{{') && !apiHost.startsWith('{{')) {
+      this.plausible.enable({
+        domain,
+        apiHost,
+      });
+    }
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -9,20 +9,13 @@ module.exports = function (environment) {
     EmberENV: {
       EXTEND_PROTOTYPES: false,
     },
-
-    // https://github.com/redpencilio/ember-plausible#configuration-options
     'ember-plausible': {
-      enabled: true, // Unless specified otherwise (test env), enabled by default
+      enabled: false, // We enable this manually when the config is provided by the server
+    },
+    plausible: {
       apiHost: '{{PLAUSIBLE_APIHOST}}',
       domain: '{{PLAUSIBLE_DOMAIN}}',
-
-      hashMode: false, // If locationType is hash, change to true
-      //trackLocalhost: true,  // Uncomment if you want your local instance to add to the statistics
-
-      enableAutoPageviewTracking: true, // if true, all page changes will send an event
-      enableAutoOutboundTracking: false, // if true, all clicks to external websites will send an event
     },
-
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
@@ -30,8 +23,6 @@ module.exports = function (environment) {
   };
 
   if (environment === 'test') {
-    ENV['ember-plausible'].enabled = false;
-
     ENV.locationType = 'none';
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;

--- a/types/ember-plausible/services/plausible.d.ts
+++ b/types/ember-plausible/services/plausible.d.ts
@@ -1,0 +1,27 @@
+declare module 'ember-plausible/services/plausible' {
+  import type Service from '@ember/service';
+
+  // https://github.com/redpencilio/ember-plausible#configuration-options
+  interface PlausibleOptions {
+    domain: string | string[];
+    apiHost: string;
+    trackLocalhost?: boolean;
+    hashMode?: boolean;
+    enableAutoPageviewTracking?: boolean;
+    enableAutoOutboundTracking?: boolean;
+  }
+
+  export default class PlausibleService extends Service {
+    isEnabled: boolean;
+    isAutoPageviewTrackingEnabled: boolean;
+    isAutoOutboundTrackingEnabled: boolean;
+
+    enable(options: PlausibleOptions): void;
+    trackPageview(): Promise<void>;
+    trackEvent(eventName: string, props: object): Promise<void>;
+    enableAutoPageviewTracking(): void;
+    disableAutoPageviewTracking(): void;
+    enableAutoOutboundTracking(): void;
+    disableAutoOutboundTracking(): void;
+  }
+}


### PR DESCRIPTION
This prevents 405 calls because of the missing domain and host configuration on the dev environment.

The setup is similar to the one in loket: https://github.com/lblod/frontend-loket/commit/8d07d41c7f0d2a89c8ff0155f8727c87e07fbf9b