### PR TITLE
Feature/setup runtime feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,49 @@ The project uses woodpecker to automate builds. The configuration files can be f
 
 
 ## Reference
+
+### Feature flags
+
+Feature flags are used to enable/disable features in the application. They are defined in [config/environment.js](config/environment.js), and can be overridden by setting a cookie in the browser console. 
+
+```javascript
+let ENV = {
+    // Other configuration settings...
+    features: {
+      'new-feature': true,    // Enable the 'new-feature' by default
+      'beta-feature': false,  // Disable the 'beta-feature' by default
+    }
+  };
+```
+
+The configuration can be manually overridden by setting a variable in the browser console, feature name have to be prefixed with `feature-`: 
+- `window.cookie='feature-new-feature=false'` to disable the 'new-feature'
+- `window.cookie='feature-beta-feature=true'` to enable the 'beta-feature'
+
+The feature flags can be used in the application by injecting the `feature` service and calling the `isEnabled` method.
+```javascript
+import { inject as service } from '@ember/service';
+
+export default class ExampleComponent extends Component {
+  @service features;
+
+  doSomething() {
+    if (this.features.isEnabled('new-feature')) {
+      // Implement the logic for the new feature
+      console.log('New feature is enabled!');
+    } else {
+      // Implement the logic for the default behavior without the new feature
+      console.log('New feature is disabled!');
+    }
+  }
+}
+
+```
+
+### List of feature flags
+|       Name        | Description |
+| ----------------- | ----------- |
+
 ### Environment variables
 |       Name        | Description |
 | ----------------- |

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ let ENV = {
   };
 ```
 
-The configuration can be manually overridden by setting a variable in the browser console, feature name have to be prefixed with `feature-`: 
-- `window.cookie='feature-new-feature=false'` to disable the 'new-feature'
-- `window.cookie='feature-beta-feature=true'` to enable the 'beta-feature'
+The configuration can be manually overridden by adding a query parameter to the URL:
+- `?feature-new-feature=false` to disable the 'new-feature'
+- `?feature-beta-feature=true` to enable the 'beta-feature'
+
+The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding `?clear-feature-overrides=true` to the URL.
 
 The feature flags can be used in the application by injecting the `features` service and calling the `isEnabled` method.
 ```javascript

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ The project uses woodpecker to automate builds. The configuration files can be f
 
 ### Feature flags
 
-Feature flags are used to enable/disable features in the application. They are defined in [config/environment.js](config/environment.js), and can be overridden by setting a cookie in the browser console. 
+Feature flags are used to enable/disable features in the application. They are defined in [config/environment.js](config/environment.js). 
 
 ```javascript
+// in config/environment.js
 let ENV = {
     // Other configuration settings...
     features: {
@@ -62,7 +63,7 @@ The configuration can be manually overridden by setting a variable in the browse
 - `window.cookie='feature-new-feature=false'` to disable the 'new-feature'
 - `window.cookie='feature-beta-feature=true'` to enable the 'beta-feature'
 
-The feature flags can be used in the application by injecting the `feature` service and calling the `isEnabled` method.
+The feature flags can be used in the application by injecting the `features` service and calling the `isEnabled` method.
 ```javascript
 import { inject as service } from '@ember/service';
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ export default class ExampleComponent extends Component {
 ### List of feature flags
 |       Name        | Description |
 | ----------------- | ----------- |
+| mu-search-agenda-items | Use mu-search in `agenda-items/index` |
 
 ### Environment variables
 |       Name        | Description |

--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -13,6 +13,7 @@ declare const config: {
     apiHost: string;
     domain: string;
   };
+  features: Record<string, boolean>;
 };
 
 export default config;

--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -13,7 +13,7 @@ declare const config: {
     apiHost: string;
     domain: string;
   };
-  features: Record<string, boolean>;
+  features: Record<string, boolean | string>;
 };
 
 export default config;

--- a/app/routes/agenda-items/index.ts
+++ b/app/routes/agenda-items/index.ts
@@ -1,6 +1,12 @@
 import Route from '@ember/routing/route';
+import Controller from '@ember/controller';
+import Transition from '@ember/routing/transition';
+import { service } from '@ember/service';
+import FeaturesService from 'frontend-burgernabije-besluitendatabank/services/features';
 
 export default class AgendaItemsIndexRoute extends Route {
+  @service declare features: FeaturesService;
+
   queryParams = {
     municipalityLabels: {
       as: 'gemeentes',
@@ -15,4 +21,20 @@ export default class AgendaItemsIndexRoute extends Route {
       as: 'trefwoord',
     },
   };
+
+  async setupController(
+    controller: Controller,
+    model: unknown,
+    transition: Transition
+  ) {
+    // if mu-search-agenda-items feature is enabled display the mu-search agenda items
+    // otherwise display the default agenda items
+    if (this.features.isEnabled('mu-search-agenda-items')) {
+      console.log('mu-search-agenda-items feature is enabled');
+      // this.controllerName = 'agenda-items/mu-search';
+      // this.templateName = 'agenda-items/mu-search';
+    }
+
+    super.setupController(controller, model, transition);
+  }
 }

--- a/app/routes/agenda-items/index.ts
+++ b/app/routes/agenda-items/index.ts
@@ -30,7 +30,9 @@ export default class AgendaItemsIndexRoute extends Route {
     // if mu-search-agenda-items feature is enabled display the mu-search agenda items
     // otherwise display the default agenda items
     if (this.features.isEnabled('mu-search-agenda-items')) {
-      console.log('mu-search-agenda-items feature is enabled');
+      console.log(
+        'mu-search-agenda-items feature is enabled, but no visible change yet'
+      );
       // this.controllerName = 'agenda-items/mu-search';
       // this.templateName = 'agenda-items/mu-search';
     }

--- a/app/services/features.ts
+++ b/app/services/features.ts
@@ -43,13 +43,13 @@ export default class FeaturesService extends Service {
   }
 
   #getConfigFeatures(): Record<string, boolean> {
-    const cookieFeatures: Record<string, boolean> = Object.fromEntries(
+    const configFeatures: Record<string, boolean> = Object.fromEntries(
       Object.entries(config.features).map(([featureName, value]) => {
         return [featureName, value === 'true' || value === true];
       })
     );
 
-    return cookieFeatures;
+    return configFeatures;
   }
 
   // cookie has to start with 'feature-{{feature-name}}'
@@ -64,19 +64,20 @@ export default class FeaturesService extends Service {
         cookieFeatures[featureName] = value === 'true';
       }
     }
+
     return cookieFeatures;
   }
 
   #setCookieFeatures(features: Record<string, boolean>) {
     for (const [featureName, featureValue] of Object.entries(features)) {
-      document.cookie = `feature-${featureName}=${featureValue}; path=/`;
+      document.cookie = `${FeaturesService.PREFIX}${featureName}=${featureValue}; path=/`;
     }
   }
 
   #clearCookieFeatures() {
     const featuresToClear = Object.keys(this.#getCookieFeatures());
     for (const featureName of featuresToClear) {
-      document.cookie = `feature-${featureName}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+      document.cookie = `${FeaturesService.PREFIX}${featureName}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
     }
   }
 
@@ -102,8 +103,8 @@ export default class FeaturesService extends Service {
   }
 
   #extractFeatureNameFromKey(key?: string): string | null {
-    if (key?.startsWith('feature-')) {
-      return key.replace('feature-', '');
+    if (key?.startsWith(FeaturesService.PREFIX)) {
+      return key.replace(FeaturesService.PREFIX, '');
     }
     return null;
   }

--- a/app/services/features.ts
+++ b/app/services/features.ts
@@ -1,0 +1,52 @@
+import Service from '@ember/service';
+import { assert } from '@ember/debug';
+import config from 'frontend-burgernabije-besluitendatabank/config/environment';
+
+export default class FeaturesService extends Service {
+  #features: Record<string, boolean> = {};
+
+  constructor() {
+    super();
+
+    const cookieFeatures = this.#getCookieFeatures();
+    this.setup({ ...config.features, ...cookieFeatures });
+  }
+
+  setup(features: Record<string, boolean>) {
+    this.#features = { ...features };
+  }
+
+  isEnabled(feature: string): boolean {
+    assert(
+      `The "${feature}" feature is not defined. Make sure the feature is defined in the "features" object in the config/environment.js file and that there are no typos in the name.`,
+      feature in this.#features
+    );
+
+    return this.#features[feature] ?? false;
+  }
+
+  // cookie has to start with 'feature-{{feature-name}}'
+  #getCookieFeatures(): Record<string, boolean> {
+    const cookieFeatures: Record<string, boolean> = {};
+    const cookies = document.cookie.split('; ');
+    for (const cookie of cookies) {
+      const [name, value] = cookie.split('=');
+      if (name?.startsWith('feature-')) {
+        const featureName = name.replace('feature-', '');
+        const featureValue = value === 'true';
+        cookieFeatures[featureName] = featureValue;
+      }
+    }
+    return cookieFeatures;
+  }
+}
+
+// Don't remove this declaration: this is what enables TypeScript to resolve
+// this service using `Owner.lookup('service:feature')`, as well
+// as to check when you pass the service name as an argument to the decorator,
+// like `@service('feature') declare altName: FeatureService;`.
+declare module '@ember/service' {
+  interface Registry {
+    features: FeaturesService;
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
       // when it is created
     },
     features: {
-      'mu-search-agenda-items': true,
+      'mu-search-agenda-items': false,
     },
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,6 +20,9 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+    features: {
+      'mu-search-agenda-items': true,
+    },
   };
 
   if (environment === 'test') {

--- a/tests/unit/utils/features-test.js
+++ b/tests/unit/utils/features-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+
+module('Unit | Service | features', function (hooks) {
+  setupTest(hooks);
+
+  this.subject = function () {
+    return this.owner.lookup('service:features');
+  };
+
+  module('isEnabled', function () {
+    test('it returns true when the feature is enabled', function (assert) {
+      const features = this.subject();
+      features.setup({ test: true });
+
+      assert.true(features.isEnabled('test'));
+    });
+
+    test('it return false when the feature is disabled', function (assert) {
+      const features = this.subject();
+      features.setup({ test: false });
+
+      assert.false(features.isEnabled('test'));
+    });
+
+    test('it throws when the feature is not configured', function (assert) {
+      const features = this.subject();
+
+      assert.throws(() => features.isEnabled('test'));
+    });
+  });
+});


### PR DESCRIPTION
Add a runtime feature flag service. 

What was done : 
- add `FeaturesService`
- add `mu-search-agenda-items` flag as an example, will be used in https://github.com/lblod/frontend-burgernabije-besluitendatabank/pull/83