### PR TITLE
Only enable the `staticEmberSources` and `amdCompatibility` options in production builds

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,6 +3,8 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+const isProductionBuild = process.env.EMBER_ENV === 'production';
+
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     '@appuniversum/ember-appuniversum': {
@@ -12,20 +14,13 @@ module.exports = function (defaults) {
 
   const { Webpack } = require('@embroider/webpack');
 
-  return require('@embroider/compat').compatBuild(app, Webpack, {
+  const embroiderOptions = {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
     staticHelpers: true,
     staticModifiers: true,
     staticComponents: true,
-    staticEmberSource: true,
-    amdCompatibility: {
-      es: [
-        // au-date-range-picker imports jquery but doesn't depend on the jquery package directly. Instead it uses `@ember/jquery` which Embroider can't detect.
-        // We can either update the addon to depend on jquery directly (+ ember-auto-import) or switch to a different solution that doesn't use jquery at all
-        ['jquery', ['default']],
-      ],
-    },
+    staticEmberSource: isProductionBuild,
 
     // This config is needed to work around an Ember Data v4.12 + Embroider issue
     // We can remove it once the fix is released: // https://github.com/embroider-build/embroider/issues/1506
@@ -37,5 +32,25 @@ module.exports = function (defaults) {
         ].filter(Boolean),
       },
     },
-  });
+  };
+
+  if (isProductionBuild) {
+    // `staticEmberSource` breaks the Ember dev tools: https://github.com/embroider-build/embroider/issues/1575
+    // As a workaround we only enable it for production builds so that we can still use the dev tools for local development
+    // while still having a smaller bundle in production.
+    embroiderOptions.staticEmberSource = true;
+    embroiderOptions.amdCompatibility = {
+      es: [
+        // au-date-range-picker imports jquery but doesn't depend on the jquery package directly. Instead it uses `@ember/jquery` which Embroider can't detect.
+        // We can either update the addon to depend on jquery directly (+ ember-auto-import) or switch to a different solution that doesn't use jquery at all
+        ['jquery', ['default']],
+      ],
+    };
+  }
+
+  return require('@embroider/compat').compatBuild(
+    app,
+    Webpack,
+    embroiderOptions
+  );
 };


### PR DESCRIPTION
When `staticEmberSource` flag is enabled, the ember source modules are no longer exposed in the AMD system. This causes issues in the Ember inspector since it assumes certain modules are available that way.

As a workaround we only enable those options in production builds. This allows us to use the dev tools for local development, but still receive the bundle size improvements in production builds.