### PR TITLE
Fix the select filters on mobile devices

### DIFF
--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -78,12 +78,13 @@
           {{/if}}
         {{/let}}
       </div>
-      <FilterSidebar 
-        @id="filtersidebar" 
+      <FilterSidebar
+        @id="filtersidebar"
         @class="c-interface__sidebar c-interface__sidebar--dialog {{if this.hasFilter 'is-visible'}}"
         {{focus-trap
           isActive=this.hasFilter
           shouldSelfFocus=true
+          additionalElements=(array "#ember-basic-dropdown-wormhole")
           focusTrapOptions=(hash
             onDeactivate=this.hideFilter
           )


### PR DESCRIPTION
Due to the focus trap it wasn't possible to use the select filters properly on mobile devices. By adding the dropdown container to the allowed list, everything works as expected again.