### PR TITLE
Use a multi-select for the municipilaties

### DIFF
--- a/app/controllers/home.ts
+++ b/app/controllers/home.ts
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { seperator } from 'frontend-burgernabije-besluitendatabank/helpers/constants';
 import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
 
 export default class HomeController extends Controller {
@@ -11,11 +12,7 @@ export default class HomeController extends Controller {
 
   /** Controls the loading animation of the "locatie's opslaan" button */
   @tracked loading = false;
-
-  @tracked selectedMunicipality: {
-    label: string;
-    id: string;
-  } | null = null;
+  @tracked selectedMunicipalities: Array<{ label: string; id: string }> = [];
 
   get municipalities() {
     return this.municipalityList.municipalities();
@@ -26,20 +23,19 @@ export default class HomeController extends Controller {
     this.loading = false;
   }
 
-  @action handleMunicipalityChange(m: { label: string; id: string }) {
-    this.selectedMunicipality = m
-      ? {
-          label: m.label,
-          id: m.id,
-        }
-      : null;
+  @action handleMunicipalityChange(
+    selectedMunicipalities: Array<{ label: string; id: string }>
+  ) {
+    this.selectedMunicipalities = selectedMunicipalities;
   }
 
   @action handleMunicipalitySelect() {
     this.loading = true;
     this.router.transitionTo('agenda-items', {
       queryParams: {
-        gemeentes: this.selectedMunicipality?.label || '',
+        gemeentes: this.selectedMunicipalities
+          .map((municipality) => municipality.label)
+          .join(seperator),
       },
     });
   }

--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -14,9 +14,9 @@
           {{did-insert this.resetLoading}}
           >
           <div class="au-o-grid__item au-u-3-4@small">
-            <PowerSelect
+            <PowerSelectMultiple
               @onChange={{this.handleMunicipalityChange}}
-              @selected={{this.selectedMunicipality}}
+              @selected={{this.selectedMunicipalities}}
               @options={{this.municipalities}}
               @allowClear={{true}}
               @searchField="label"
@@ -24,10 +24,10 @@
               @noMatchesMessage={{"Geen gemeente gevonden"}}
               @searchMessage="Aan het zoeken..."
               @searchEnabled={{true}}
-              as |singleSelect|
+              as |municipality|
             >
-              {{singleSelect.label}}
-            </PowerSelect>
+              {{municipality.label}}
+            </PowerSelectMultiple>
           </div>
           <div class="au-o-grid__item au-u-1-4@small">
             <AuButton


### PR DESCRIPTION
This converts the municipality select on the home page to a multi-select which makes it consistent with the filter. The behavior now also matches the label above it.