### PR TITLE
Refactor the `separator` constant

### DIFF
--- a/app/components/filters/filter.ts
+++ b/app/components/filters/filter.ts
@@ -1,16 +1,17 @@
 import Component from '@glimmer/component';
 import RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
-import { get } from '@ember/object';
+
+export interface FilterArgs {
+  id: string;
+  queryParam: string;
+
+  searchField: string;
+  options: Array<object>;
+}
 
 interface Signature {
-  Args: {
-    id: string;
-    queryParam: string;
-
-    searchField: string;
-    options: Array<object>;
-  };
+  Args: FilterArgs;
 }
 
 export default class FilterComponent<S = Signature> extends Component<S> {
@@ -21,8 +22,8 @@ export default class FilterComponent<S = Signature> extends Component<S> {
    * @param param name of the queryParameter that is presented to the user
    * @returns queryParameter value. Possibly undefined
    */
-  getQueryParam(param: string) {
-    return get(this.router.currentRoute.queryParams, param);
+  getQueryParam(param: string): string | undefined {
+    return this.router.currentRoute.queryParams[param];
   }
 
   /**

--- a/app/controllers/home.ts
+++ b/app/controllers/home.ts
@@ -3,8 +3,8 @@ import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { seperator } from 'frontend-burgernabije-besluitendatabank/helpers/constants';
 import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
+import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
 export default class HomeController extends Controller {
   @service declare router: RouterService;
@@ -33,9 +33,9 @@ export default class HomeController extends Controller {
     this.loading = true;
     this.router.transitionTo('agenda-items', {
       queryParams: {
-        gemeentes: this.selectedMunicipalities
-          .map((municipality) => municipality.label)
-          .join(seperator),
+        gemeentes: serializeArray(
+          this.selectedMunicipalities.map((municipality) => municipality.label)
+        ),
       },
     });
   }

--- a/app/helpers/constants.ts
+++ b/app/helpers/constants.ts
@@ -1,2 +1,0 @@
-/** Character(s) used for the select-multiple-filter */
-export const seperator = '+';

--- a/app/services/municipality-list.ts
+++ b/app/services/municipality-list.ts
@@ -1,7 +1,7 @@
 import Service, { service } from '@ember/service';
 import Store from '@ember-data/store';
 import LocationModel from 'frontend-burgernabije-besluitendatabank/models/location';
-import { seperator } from 'frontend-burgernabije-besluitendatabank/helpers/constants';
+import { deserializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
 export default class MunicipalityListService extends Service {
   @service declare store: Store;
@@ -54,11 +54,10 @@ export default class MunicipalityListService extends Service {
    * @returns a Promise for a joined string of those locations' id's, or undefined
    */
   async getLocationIdsFromLabels(
-    labels?: Array<string> | string,
-    stringSeperator = seperator
+    labels?: Array<string> | string
   ): Promise<string | undefined> {
     if (typeof labels === 'string') {
-      labels = labels.split(stringSeperator);
+      labels = deserializeArray(labels);
     } else if (!labels) {
       return undefined;
     }

--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -102,7 +102,6 @@
             @searchField="label"
             @queryParam="gemeentes"
             @placeholder="Alle gemeentes"
-            @value={{this.municipality}}
           />
           <Filters::DateRangeFilter
             @startQueryParam="begin"

--- a/app/templates/sessions/index.hbs
+++ b/app/templates/sessions/index.hbs
@@ -48,7 +48,6 @@
           @searchField="label"
           @queryParam="gemeentes"
           @placeholder="Alle gemeentes"
-          @value={{this.municipality}}
         />
         <Filters::DateRangeFilter
           @startQueryParam="begin"

--- a/app/utils/query-params.ts
+++ b/app/utils/query-params.ts
@@ -1,0 +1,9 @@
+const SEPARATOR = '+';
+
+export function serializeArray(array: string[]): string {
+  return array.join(SEPARATOR);
+}
+
+export function deserializeArray(arrayString: string): string[] {
+  return arrayString.split(SEPARATOR);
+}


### PR DESCRIPTION
Extracting the logic to some utils makes the separator an implementation detail so it's easier to change in the future.