### PR TITLE
feat(agenda-item): Update `wasHandled` computation

### DIFF
--- a/app/controllers/agenda-items/agenda-item.ts
+++ b/app/controllers/agenda-items/agenda-item.ts
@@ -13,7 +13,10 @@ export default class AgendaItemController extends Controller {
   }
 
   get wasHandled() {
-    return Boolean(this.model.agendaItem.belongsTo('handledBy').value());
+    return (
+      Boolean(this.model.agendaItem?.session?.startedAt) ||
+      Boolean(this.model.agendaItem?.session?.endedAt)
+    );
   }
 
   get municipalityQuery() {

--- a/app/models/agenda-item.ts
+++ b/app/models/agenda-item.ts
@@ -8,6 +8,7 @@ import Model, {
 } from '@ember-data/model';
 import AgendaItemHandlingModel from './agenda-item-handling';
 import SessionModel from './session';
+import { sortSessions } from 'frontend-burgernabije-besluitendatabank/utils/sort-sessions';
 
 export default class AgendaItemModel extends Model {
   @attr('string', { defaultValue: 'Ontbrekende titel' }) declare title: string;
@@ -31,15 +32,8 @@ export default class AgendaItemModel extends Model {
       .hasMany('sessions')
       ?.value();
 
-    // We want to use a session with municipality
-    let session = sessions?.find((session) => {
-      return session.hasMunicipality;
-    });
-
-    // If not found, use the first session
-    if (!session) {
-      session = sessions?.firstObject;
-    }
+    // We want to use a session with municipality and start date in priority
+    const session = sessions?.slice()?.sort(sortSessions)?.shift();
 
     return session;
   }

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -215,12 +215,6 @@
                   @icon="decided"
                   @title="Dit werd behandeld"
                 />
-              {{else}}
-                <AuAlert
-                  @skin="warning"
-                  @icon="three-dots"
-                  @title="Dit werd nog niet behandeld"
-                />
               {{/if}}
             </div>
             {{#if this.model.agendaItem.session.hasMunicipality}}

--- a/app/utils/sort-sessions.ts
+++ b/app/utils/sort-sessions.ts
@@ -1,0 +1,20 @@
+import SessionModel from 'frontend-burgernabije-besluitendatabank/models/session';
+
+// Sort sessions based on the presence of "municipality" and "startedAt"
+export const sortSessions = (a: SessionModel, b: SessionModel) => {
+  const hasMunicipalityA = 'municipality' in a;
+  const hasMunicipalityB = 'municipality' in b;
+  const hasStartedAtA = 'startedAt' in a;
+  const hasStartedAtB = 'startedAt' in b;
+
+  // First, sort based on the presence of "municipality"
+  if (hasMunicipalityA && !hasMunicipalityB) return -1;
+  if (!hasMunicipalityA && hasMunicipalityB) return 1;
+
+  // Then, sort based on the presence of "startedAt"
+  if (hasStartedAtA && !hasStartedAtB) return -1;
+  if (!hasStartedAtA && hasStartedAtB) return 1;
+
+  // If both objects have or don't have "municipality" and "startedAt", no preference
+  return 0;
+};

--- a/tests/unit/utils/sort-sessions-test.js
+++ b/tests/unit/utils/sort-sessions-test.js
@@ -1,0 +1,24 @@
+import { sortSessions } from 'frontend-burgernabije-besluitendatabank/utils/sort-sessions';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | sort-sessions', function () {
+  module('sortSessions', function () {
+    test('it sorts the array of objects based on priority', function (assert) {
+      const source = [
+        { startedAt: '2022-02-05' },
+        { startedAt: '2022-01-15', municipality: 'A' },
+        { municipality: 'C' },
+      ];
+
+      const sorted = [
+        { startedAt: '2022-01-15', municipality: 'A' },
+        { municipality: 'C' },
+        { startedAt: '2022-02-05' },
+      ];
+
+      const result = source.sort(sortSessions);
+
+      assert.deepEqual(result, sorted);
+    });
+  });
+});


### PR DESCRIPTION
Use session `startedAt` and `endedAt` instead of handledBy value. 

Related to https://binnenland.atlassian.net/browse/BNB-335

## Before

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/716cc5ba-a1cd-484e-8c26-9d67a285599c)

## After

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/4aca9814-c20a-44c2-8bb6-e66bbc6a6ee0)

