### PR TITLE
fix: Remove remained `not handeled` alert

### DIFF
--- a/app/templates/agenda-items/agenda-item/index.hbs
+++ b/app/templates/agenda-items/agenda-item/index.hbs
@@ -28,13 +28,6 @@
               @title="Dit werd behandeld"
               class="au-u-margin-bottom-none"
             />
-          {{else}}
-            <AuAlert
-              @skin="warning"
-              @icon="three-dots"
-              @title="Dit werd nog niet behandeld"
-              class="au-u-margin-bottom-none"
-            />
           {{/if}}
         </div>
         <article


### PR DESCRIPTION
Fix mobile view

Before

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/6c16c9be-fdd0-43fd-9849-3e1341ff2b93)

After

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/0869a9a4-e4ad-4925-ab7c-cd280672cb11)
