### PR TITLE
Fix muSearch description as string[]

### DIFF
--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -5,7 +5,10 @@ import { task } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
 import AgendaItem from 'frontend-burgernabije-besluitendatabank/models/mu-search/agenda-item';
-import { parseMuSearchAttributeToDate } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
+import {
+  parseMuSearchAttributeToDate,
+  parseMuSearchAttributeToString,
+} from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
 import { cleanString } from 'frontend-burgernabije-besluitendatabank/utils/clean-string';
 import MuSearchService, {
   DataMapper,
@@ -248,14 +251,22 @@ const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (
 
   // Map data attributes to AgendaItem properties
   dataResponse.id = Array.isArray(uuid) ? uuid[0] : uuid;
-  dataResponse.title = cleanString(entry.title);
-  dataResponse.description = cleanString(entry.description);
+  dataResponse.title = cleanString(parseMuSearchAttributeToString(entry.title));
+  dataResponse.description = cleanString(
+    parseMuSearchAttributeToString(entry.description)
+  );
   dataResponse.locationId = entry.location_id || entry.abstract_location_id;
   dataResponse.abstractGoverningBodyLocationName =
-    entry.abstract_governing_body_location_name;
-  dataResponse.governingBodyLocationName = entry.governing_body_location_name;
-  dataResponse.abstractGoverningBodyName = entry.abstract_governing_body_name;
-  dataResponse.governingBodyName = entry.governing_body_name;
+    parseMuSearchAttributeToString(entry.abstract_governing_body_location_name);
+  dataResponse.governingBodyLocationName = parseMuSearchAttributeToString(
+    entry.governing_body_location_name
+  );
+  dataResponse.abstractGoverningBodyName = parseMuSearchAttributeToString(
+    entry.abstract_governing_body_name
+  );
+  dataResponse.governingBodyName = parseMuSearchAttributeToString(
+    entry.governing_body_name
+  );
   dataResponse.sessionPlannedStart = parseMuSearchAttributeToDate(
     entry.session_planned_start
   );

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -168,6 +168,7 @@ type AgendaItemsQueryArguments = {
 
 type AgendaItemMuSearchEntry = {
   uuid: string[] | string;
+  abstract_location_id?: string;
   location_id?: string;
   abstract_governing_body_location_name?: string;
   governing_body_location_name?: string;
@@ -249,7 +250,7 @@ const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (
   dataResponse.id = Array.isArray(uuid) ? uuid[0] : uuid;
   dataResponse.title = cleanString(entry.title);
   dataResponse.description = cleanString(entry.description);
-  dataResponse.locationId = entry.location_id;
+  dataResponse.locationId = entry.location_id || entry.abstract_location_id;
   dataResponse.abstractGoverningBodyLocationName =
     entry.abstract_governing_body_location_name;
   dataResponse.governingBodyLocationName = entry.governing_body_location_name;

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -5,7 +5,7 @@ import { task } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
 import AgendaItem from 'frontend-burgernabije-besluitendatabank/models/mu-search/agenda-item';
-import { parseMuSearchDateToDate } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
+import { parseMuSearchAttributeToDate } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
 import { cleanString } from 'frontend-burgernabije-besluitendatabank/utils/clean-string';
 import MuSearchService, {
   DataMapper,
@@ -255,11 +255,13 @@ const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (
   dataResponse.governingBodyLocationName = entry.governing_body_location_name;
   dataResponse.abstractGoverningBodyName = entry.abstract_governing_body_name;
   dataResponse.governingBodyName = entry.governing_body_name;
-  dataResponse.sessionPlannedStart = parseMuSearchDateToDate(
+  dataResponse.sessionPlannedStart = parseMuSearchAttributeToDate(
     entry.session_planned_start
   );
-  dataResponse.sessionEndedAt = parseMuSearchDateToDate(entry.session_ended_at);
-  dataResponse.sessionStartedAt = parseMuSearchDateToDate(
+  dataResponse.sessionEndedAt = parseMuSearchAttributeToDate(
+    entry.session_ended_at
+  );
+  dataResponse.sessionStartedAt = parseMuSearchAttributeToDate(
     entry.session_started_at
   );
 

--- a/app/utils/mu-search-data-format.ts
+++ b/app/utils/mu-search-data-format.ts
@@ -1,4 +1,4 @@
-export const parseMuSearchDateToDate = (
+export const parseMuSearchAttributeToDate = (
   input: string | string[] | undefined
 ): Date | undefined => {
   // Check if input is undefined or an empty array
@@ -8,7 +8,7 @@ export const parseMuSearchDateToDate = (
 
   // Always take the first element if input is an array
   if (Array.isArray(input)) {
-    return parseMuSearchDateToDate(input[0]);
+    return parseMuSearchAttributeToDate(input[0]);
   }
 
   // Attempt to parse the input string into a Date

--- a/app/utils/mu-search-data-format.ts
+++ b/app/utils/mu-search-data-format.ts
@@ -21,3 +21,19 @@ export const parseMuSearchAttributeToDate = (
 
   return date;
 };
+
+export const parseMuSearchAttributeToString = (
+  input: string | string[] | undefined
+): string | undefined => {
+  // Check if input is undefined or an empty array
+  if (!input || (Array.isArray(input) && input.length === 0)) {
+    return undefined;
+  }
+
+  // Always take the first element if input is an array
+  if (Array.isArray(input)) {
+    return parseMuSearchAttributeToString(input[0]);
+  }
+
+  return input;
+};

--- a/tests/unit/utils/mu-search-data-format-test.js
+++ b/tests/unit/utils/mu-search-data-format-test.js
@@ -1,5 +1,8 @@
 import { module, test } from 'qunit';
-import { parseMuSearchAttributeToDate } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
+import {
+  parseMuSearchAttributeToDate,
+  parseMuSearchAttributeToString,
+} from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
 
 module('Unit | Utility | mu-search-data-format', function () {
   module('parseMuSearchAttributeToDate', function () {
@@ -26,6 +29,23 @@ module('Unit | Utility | mu-search-data-format', function () {
 
     test('it returns undefined when wrong string', function (assert) {
       assert.deepEqual(parseMuSearchAttributeToDate('wrong-string'), undefined);
+    });
+  });
+
+  module('parseMuSearchAttributeToString', function () {
+    test('it returns a string when input is a string', function (assert) {
+      assert.deepEqual(parseMuSearchAttributeToString('test'), 'test');
+    });
+
+    test('it returns the first string when input is an array of strings', function (assert) {
+      assert.deepEqual(
+        parseMuSearchAttributeToString(['test', 'test2']),
+        'test'
+      );
+    });
+
+    test('it returns undefined when no input', function (assert) {
+      assert.deepEqual(parseMuSearchAttributeToString(), undefined);
     });
   });
 });

--- a/tests/unit/utils/mu-search-data-format-test.js
+++ b/tests/unit/utils/mu-search-data-format-test.js
@@ -1,18 +1,18 @@
 import { module, test } from 'qunit';
-import { parseMuSearchDateToDate } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
+import { parseMuSearchAttributeToDate } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
 
 module('Unit | Utility | mu-search-data-format', function () {
-  module('parseDateStringToDate', function () {
+  module('parseMuSearchAttributeToDate', function () {
     test('it returns a Date when input string is valid', function (assert) {
       assert.deepEqual(
-        parseMuSearchDateToDate('2022-11-29T20:00:00+01:00'),
+        parseMuSearchAttributeToDate('2022-11-29T20:00:00+01:00'),
         new Date('2022-11-29T20:00:00+01:00')
       );
     });
 
     test('it returns the first date when input is an array of strings', function (assert) {
       assert.deepEqual(
-        parseMuSearchDateToDate([
+        parseMuSearchAttributeToDate([
           '2023-01-26T19:35:00+01:00',
           '2022-11-29T20:00:00+01:00',
         ]),
@@ -21,11 +21,11 @@ module('Unit | Utility | mu-search-data-format', function () {
     });
 
     test('it returns undefined when no input', function (assert) {
-      assert.deepEqual(parseMuSearchDateToDate(), undefined);
+      assert.deepEqual(parseMuSearchAttributeToDate(), undefined);
     });
 
     test('it returns undefined when wrong string', function (assert) {
-      assert.deepEqual(parseMuSearchDateToDate('wrong-string'), undefined);
+      assert.deepEqual(parseMuSearchAttributeToDate('wrong-string'), undefined);
     });
   });
 });


### PR DESCRIPTION
- [feat(musearch): Add parseMuSearchAttributeToString and apply on all string attributes](https://github.com/lblod/frontend-burgernabije-besluitendatabank/commit/c57e0cf0716ca52ee134d7de5718c95fb1330e82)
- [Add missing abstract_location_id attribute](https://github.com/lblod/frontend-burgernabije-besluitendatabank/commit/0258bf2c4bf83977b2db27d963e36c065392cf48)
- [refactor: Rename parseMuSearchAttributeToDate](https://github.com/lblod/frontend-burgernabije-besluitendatabank/commit/eccd385e1497a3d6ffa39d2c6d454ea7ee7f56f5)

Before

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/7a6a8d18-8b12-43ef-bd6f-7c7233c83de4)


After

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/a643724c-3af1-4cb3-abf1-1b38ea7de00e)
