### PR TITLE
Simplify daterange component

### DIFF
--- a/app/components/filters/date-range-filter.hbs
+++ b/app/components/filters/date-range-filter.hbs
@@ -40,8 +40,8 @@
       <Filters::DateRangeFilter::DateInput
         @value={{this.end}}
         @onChange={{this.handleEndDateChange}}
-        @max={{this.max}}
-        @min={{this.min}}
+        @max={{this.MAX}}
+        @min={{this.MIN}}
         @errorMessage={{this.endDateError}}
         id="date-to"
         data-test-date-range-filter-to

--- a/app/components/filters/date-range-filter.hbs
+++ b/app/components/filters/date-range-filter.hbs
@@ -25,23 +25,27 @@
     <AuLabel for="date-from">Startdatum</AuLabel>
     <Filters::DateRangeFilter::DateInput
       @value={{this.start}}
-      @max={{this.max}}
-      @min={{this.min}}
+      @max={{this.MAX}}
+      @min={{this.MIN}}
       @onChange={{this.handleStartDateChange}}
       @errorMessage={{this.startDateError}}
       id="date-from"
+      data-test-date-range-filter-from
+      data-test-date-range-filter-from-error={{this.startDateError}}
     />
   </AuFormRow>
   <div>
     <AuFormRow>
-      <AuLabel for="date-until">Einddatum</AuLabel>
+      <AuLabel for="date-to">Einddatum</AuLabel>
       <Filters::DateRangeFilter::DateInput
         @value={{this.end}}
         @onChange={{this.handleEndDateChange}}
         @max={{this.max}}
         @min={{this.min}}
         @errorMessage={{this.endDateError}}
-        id="date-until"
+        id="date-to"
+        data-test-date-range-filter-to
+        data-test-date-range-filter-to-error={{this.endDateError}}
       />
     </AuFormRow>
 

--- a/app/components/filters/date-range-filter/toggle-button.hbs
+++ b/app/components/filters/date-range-filter/toggle-button.hbs
@@ -3,5 +3,6 @@
     @icon={{@icon}}
     @skin="naked"
     {{on "click" @onClick}}
+    data-test-filters-toggle-button
   >{{yield}}</AuButton>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "ember-resources": "^6.3.1",
         "ember-source": "~4.12.0",
         "ember-template-lint": "^5.7.2",
+        "ember-test-selectors": "^6.0.0",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-ember": "^11.5.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "ember-resources": "^6.3.1",
     "ember-source": "~4.12.0",
     "ember-template-lint": "^5.7.2",
+    "ember-test-selectors": "^6.0.0",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",

--- a/tests/integration/components/filters/date-range-filter-test.js
+++ b/tests/integration/components/filters/date-range-filter-test.js
@@ -1,0 +1,148 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import { click, fillIn, find, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | filters/date-range-filter', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function () {
+    await render(hbs`<Filters::DateRangeFilter />`);
+  });
+
+  const toggleButtonSelector = async () =>
+    await find('[data-test-filters-toggle-button]');
+
+  test('it displays presets by default', async function (assert) {
+    assert
+      .dom(this.element)
+      .hasText('Selecteer een periode Alle periodes Eigen periode kiezen');
+  });
+
+  test('it switches between presets and custom date range when click the toggle button', async function (assert) {
+    assert.expect(2);
+
+    let toggleButton = await toggleButtonSelector();
+    await click(toggleButton);
+
+    assert.deepEqual(toggleButton.textContent.trim(), 'Eigen periode kiezen');
+
+    toggleButton = await toggleButtonSelector();
+    await click(toggleButton);
+
+    assert.deepEqual(toggleButton.textContent.trim(), 'Bestaande periodes');
+  });
+
+  module('when custom date range is selected', function (hooks) {
+    hooks.beforeEach(async function () {
+      await click(await toggleButtonSelector());
+      this.router = this.owner.lookup('service:router');
+      this.router.transitionTo = sinon.stub();
+    });
+
+    const dateRangeFilterFromSelector = async () =>
+      await find('[data-test-date-range-filter-from]');
+
+    const dateRangeFilterToSelector = async () =>
+      await find('[data-test-date-range-filter-to]');
+
+    test('it updates queryParams when date valide ', async function (assert) {
+      assert.expect(2);
+
+      await fillIn(await dateRangeFilterFromSelector(), '2023-01-01');
+
+      assert.true(this.router.transitionTo.calledOnce);
+      assert.deepEqual(this.router.transitionTo.getCall(0).args, [
+        {
+          queryParams: {
+            end: null,
+            start: '2023-01-01',
+          },
+        },
+      ]);
+    });
+
+    test('it updates queryParams when date is cleared', async function (assert) {
+      assert.expect(3);
+
+      await fillIn(await dateRangeFilterFromSelector(), '2023-01-01');
+      await fillIn(await dateRangeFilterFromSelector(), '');
+
+      assert.true(this.router.transitionTo.calledTwice);
+      assert.deepEqual(this.router.transitionTo.getCall(0).args[0], {
+        queryParams: {
+          end: null,
+          start: '2023-01-01',
+        },
+      });
+      assert.deepEqual(this.router.transitionTo.getCall(1).args[0], {
+        queryParams: {
+          end: null,
+          start: null,
+        },
+      });
+    });
+
+    test('it displays error when from date is before 2015', async function (assert) {
+      assert.expect(2);
+
+      await fillIn(await dateRangeFilterFromSelector(), '2014-12-31');
+      await fillIn(await dateRangeFilterToSelector(), '2014-12-31');
+
+      assert
+        .dom(
+          '[data-test-date-range-filter-from-error="De startdatum moet tussen 1 januari 2015 en 31 december 2100 liggen"]'
+        )
+        .exists();
+
+      assert
+        .dom(
+          '[data-test-date-range-filter-to-error="De einddatum moet tussen 1 januari 2015 en 31 december 2100 liggen"]'
+        )
+        .exists();
+    });
+
+    test('it displays error when to date is after 2100', async function (assert) {
+      assert.expect(2);
+
+      await fillIn(await dateRangeFilterFromSelector(), '2101-01-01');
+      await fillIn(await dateRangeFilterToSelector(), '2101-01-01');
+
+      assert
+        .dom(
+          '[data-test-date-range-filter-from-error="De startdatum moet tussen 1 januari 2015 en 31 december 2100 liggen"]'
+        )
+        .exists();
+
+      assert
+        .dom(
+          '[data-test-date-range-filter-to-error="De einddatum moet tussen 1 januari 2015 en 31 december 2100 liggen"]'
+        )
+        .exists();
+    });
+
+    test('it displays error when from date is after to date', async function (assert) {
+      assert.expect(3);
+
+      await fillIn(await dateRangeFilterFromSelector(), '2023-12-31');
+      await fillIn(await dateRangeFilterToSelector(), '2023-01-01');
+
+      assert
+        .dom(
+          '[data-test-date-range-filter-to-error="De startdatum moet voor de einddatum liggen"]'
+        )
+        .exists();
+
+      assert.true(this.router.transitionTo.calledOnce);
+      assert.deepEqual(this.router.transitionTo.getCall(0).args, [
+        {
+          queryParams: {
+            end: null,
+            start: '2023-12-31',
+          },
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
@snenenenenenene This a proposal to simplify the way that error handling is managed on the component. 

It fix 2 broken behaviors : 
- When remove the value of start or end input date, the URL is not updated (date not removed) due to `isDateComplete`; 
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/ec0795f6-3ade-4612-91ce-dd2672f32444)

- When both inputs have errors, and you fix one, the error still visible. 
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/23e3789f-6146-4a72-917b-840b5b58b1e1)
