### PR TITLE
Clean municipality list

### DIFF
--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -136,7 +136,7 @@ export default class AgendaItemsIndexController extends Controller {
   AgendaItemsLoader = AgendaItemsLoader;
 
   get municipalities() {
-    return this.municipalityList.municipalities();
+    return this.municipalityList.municipalityLabels();
   }
 
   updateKeyword = (value: string) => {

--- a/app/controllers/home.ts
+++ b/app/controllers/home.ts
@@ -15,7 +15,7 @@ export default class HomeController extends Controller {
   @tracked selectedMunicipalities: Array<{ label: string; id: string }> = [];
 
   get municipalities() {
-    return this.municipalityList.municipalities();
+    return this.municipalityList.municipalityLabels();
   }
 
   /** Resets the button loading animation */

--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -25,7 +25,7 @@ export default class SessionsIndexController extends Controller {
   municipalityLabels?: string;
 
   get municipalities() {
-    return this.municipalityList.municipalities();
+    return this.municipalityList.municipalityLabels();
   }
 
   setup() {

--- a/app/services/municipality-list.ts
+++ b/app/services/municipality-list.ts
@@ -56,26 +56,18 @@ export default class MunicipalityListService extends Service {
   async getLocationIdsFromLabels(
     labels?: Array<string> | string
   ): Promise<string | undefined> {
+    const municipalities = await this.municipalities();
     if (typeof labels === 'string') {
       labels = deserializeArray(labels);
-    } else if (!labels) {
+    }
+
+    if (!labels || !municipalities) {
       return undefined;
     }
 
-    const locationIds: Array<string> = [];
-    const municipalities = await this.municipalities();
-
-    if (municipalities) {
-      for (let i = 0; i < labels.length; i++) {
-        const label = labels[i];
-        const municipality = municipalities.find(
-          (municipality) => municipality.label === label
-        );
-        if (municipality) {
-          locationIds.push(municipality.id);
-        }
-      }
-    }
+    const locationIds: Array<string> = municipalities
+      .filter(({ label }) => labels?.includes(label))
+      .map(({ id }) => id);
 
     return locationIds.join(',');
   }

--- a/app/services/municipality-list.ts
+++ b/app/services/municipality-list.ts
@@ -3,10 +3,13 @@ import Store from '@ember-data/store';
 import LocationModel from 'frontend-burgernabije-besluitendatabank/models/location';
 import { deserializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
+type Municipality = { label: string; id: string };
+
 export default class MunicipalityListService extends Service {
   @service declare store: Store;
 
-  private _municipalities?: Array<{ label: string; id: string }>;
+  private _municipalities?: Array<Municipality>;
+  private _municipalityCleanedLabels?: Array<{ label: string }>;
 
   /**
    * Get all municipalities
@@ -22,6 +25,46 @@ export default class MunicipalityListService extends Service {
     }
 
     return this._municipalities;
+  }
+
+  /**
+   * Get all municipalities, filtered on the following criteria:
+   * - no duplicate labels
+   * - remove 'Kruishoutem' (because it's not a municipality anymore) #BNB-402
+   *
+   * Filtering is managed frontend as a temporary solution ^^
+   * TODO: move this to the backend
+   *
+   * @returns A promise for an array of municipality labels
+   **/
+
+  async municipalityLabels() {
+    if (!this._municipalityCleanedLabels) {
+      this._municipalityCleanedLabels = this._filteredMunicipalities(
+        await this.municipalities()
+      );
+    }
+
+    return this._municipalityCleanedLabels;
+  }
+
+  private _filteredMunicipalities(municipalities?: Array<Municipality>) {
+    if (!municipalities) {
+      return [];
+    }
+
+    const uniqueLabels = [
+      ...new Set(
+        municipalities
+          .filter(
+            (municipality) =>
+              municipality.label && municipality.label !== 'Kruishoutem'
+          )
+          .map(({ label }) => label)
+      ),
+    ].map((label) => ({ label }));
+
+    return uniqueLabels;
   }
 
   /**

--- a/tests/unit/services/municipality-list-test.js
+++ b/tests/unit/services/municipality-list-test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import sinon from 'sinon';
+
+module('Unit | Service | municipality-list', function (hooks) {
+  setupTest(hooks);
+
+  this.subject = function () {
+    return this.owner.lookup('service:municipality-list');
+  };
+
+  let queryStub;
+  hooks.beforeEach(function () {
+    queryStub = sinon.stub(this.owner.lookup('service:store'), 'query');
+    queryStub
+      .withArgs('location', {
+        page: { size: 600 },
+        filter: {
+          niveau: 'Gemeente',
+        },
+        sort: ':no-case:label',
+      })
+      .resolves([
+        {
+          id: 'e60532b5e10070b48664b998e12af31cd4e612a0b8d089804d0bbed3d4ecc969',
+          label: 'Aalst',
+        },
+        {
+          id: '7a7daa48e9e6449358cf96be6c7b30466648d31236e56b8958fae7d53e2308b8',
+          label: 'Aalter',
+        },
+        {
+          id: 'a0e4508a-a20b-42e5-a40d-4d919d045fdd',
+          label: 'Aalter',
+        },
+        {
+          id: '9398188baec8d653dec67da8687d5a3fec3868ca3e068306a79c6d72e5c88b19',
+          label: 'Kruishoutem',
+        },
+      ]);
+  });
+
+  hooks.afterEach(function () {
+    queryStub.restore();
+  });
+
+  test('it fetches municipalities', async function (assert) {
+    const service = this.subject();
+    const municipalities = await service.municipalities();
+
+    assert.strictEqual(municipalities.length, 4);
+  });
+
+  test('it deduplicates municipalities label and filter out `Kruishoutem`', async function (assert) {
+    const service = this.subject();
+    const municipalityLabels = await service.municipalityLabels();
+
+    assert.deepEqual(municipalityLabels, [
+      {
+        label: 'Aalst',
+      },
+      {
+        label: 'Aalter',
+      },
+    ]);
+  });
+
+  test('it returns all ids for a duplicate label', async function (assert) {
+    const service = this.subject();
+    const ids = await service.getLocationIdsFromLabels('Aalter');
+
+    assert.strictEqual(
+      ids,
+      [
+        '7a7daa48e9e6449358cf96be6c7b30466648d31236e56b8958fae7d53e2308b8',
+        'a0e4508a-a20b-42e5-a40d-4d919d045fdd',
+      ].join()
+    );
+  });
+});


### PR DESCRIPTION
- Add `municipalitieLabels` method in municipality-list service, that de-duplicate labels and remove `Kruishoutem`. 
- Use the new method in municipality-selector

BEFORE

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/f514e462-21e9-45c0-92ac-e3ed1f1cc19d)
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/889021b0-2072-4f42-b946-c0b08e211f6c)


AFTER

![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/16d2f0a9-1926-40c1-b404-6ab548939bb1)
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/e597f7b2-d10f-4b17-9dfd-1c5c1783f571)
