### PR TITLE
fix: :bug: open accordion when a bestuursorgaan is being queried

### DIFF
--- a/app/components/accordion.hbs
+++ b/app/components/accordion.hbs
@@ -1,0 +1,54 @@
+<div class="au-c-accordion {{this.skin}} {{this.reverse}}" ...attributes>
+  <AuToolbar
+    @nowrap={{true}}
+    @reverse={{@reverse}}
+    {{on "click" this.toggleAccordion}}
+    data-test-accordion-toggle
+    as |Group|
+  >
+    <Group>
+      <div>
+        <AuButton
+          @skin="link"
+          aria-expanded="{{if this.isOpen 'true' 'false'}}"
+          data-test-accordion-button
+        >
+          {{@buttonLabel}}
+        </AuButton>
+        {{#if @subtitle}}
+          <p data-test-accordion-subtitle>
+            {{@subtitle}}
+          </p>
+        {{/if}}
+      </div>
+    </Group>
+    <Group>
+      {{#if this.isOpen}}
+        <AuIcon
+          @icon={{this.iconOpen}}
+          @alignment="left"
+          @size="large"
+          @ariaHidden={{true}}
+          data-test-accordion-icon-open={{this.iconOpen}}
+        />
+      {{else}}
+        <AuIcon
+          @icon={{this.iconClosed}}
+          @alignment="left"
+          @size="large"
+          @ariaHidden={{true}}
+          data-test-accordion-icon-closed={{this.iconClosed}}
+        />
+      {{/if}}
+    </Group>
+  </AuToolbar>
+  {{#if this.isOpen}}
+    <AuContent tabindex="0" data-test-accordion-content>
+      {{#if this.loading}}
+        <AuLoader data-test-accordion-loader />
+      {{else}}
+        {{yield}}
+      {{/if}}
+    </AuContent>
+  {{/if}}
+</div>

--- a/app/components/accordion.ts
+++ b/app/components/accordion.ts
@@ -1,0 +1,56 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface ArgsInterface {
+  loading: boolean;
+  iconOpen: string;
+  iconClosed: string;
+  defaultOpen: boolean;
+  skin: string;
+  reverse: boolean;
+}
+
+export default class Accordion extends Component<ArgsInterface> {
+  get defaultOpen() {
+    return this.args.defaultOpen ?? false;
+  }
+
+  @tracked isOpen = this.defaultOpen;
+
+  get loading() {
+    if (this.args.loading) return 'is-loading';
+    else return '';
+  }
+
+  get iconOpen() {
+    if (this.args.iconOpen) {
+      return this.args.iconOpen;
+    } else {
+      return 'nav-down';
+    }
+  }
+
+  get iconClosed() {
+    if (this.args.iconClosed) {
+      return this.args.iconClosed;
+    } else {
+      return 'nav-right';
+    }
+  }
+
+  get skin() {
+    if (this.args.skin == 'border') return 'au-c-accordion--border';
+    return '';
+  }
+
+  get reverse() {
+    if (this.args.reverse) return 'au-c-accordion--reverse';
+    return '';
+  }
+
+  @action
+  toggleAccordion() {
+    this.isOpen = !this.isOpen;
+  }
+}

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -172,7 +172,6 @@ export default class AgendaItemsIndexController extends Controller {
   @tracked showAdvancedFilters = this.governingBodyClassifications.length > 0;
 
   @action handleDateSortChange(event: { target: { value: string } }) {
-    console.log(this.showAdvancedFilters);
     this.dateSort = event?.target?.value;
   }
 

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -153,15 +153,6 @@ export default class AgendaItemsIndexController extends Controller {
     this.governmentList.selectedLocalGovernments = newOptions;
   }
 
-  @tracked showAdvancedFilters = false;
-
-  @action toggleAdvancedFilters() {
-    if (this.showAdvancedFilters && this.governingBodyClassifications !== '') {
-      this.governingBodyClassifications = '';
-    }
-    this.showAdvancedFilters = !this.showAdvancedFilters;
-  }
-
   get localGovernmentGroupOptions() {
     return Promise.all([this.municipalities, this.provinces]).then(
       ([municipalities, provinces]) => [
@@ -178,7 +169,10 @@ export default class AgendaItemsIndexController extends Controller {
   @tracked plannedStartMax = '';
   @tracked governingBodyClassifications = '';
 
+  @tracked showAdvancedFilters = this.governingBodyClassifications.length > 0;
+
   @action handleDateSortChange(event: { target: { value: string } }) {
+    console.log(this.showAdvancedFilters);
     this.dateSort = event?.target?.value;
   }
 

--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -166,8 +166,8 @@
           @end={{this.plannedStartMax}}
         />
         <section class="c-advanced-filter-holder">
-          <AuAccordion
-            @open={{this.showAdvancedFilters}}
+          <Accordion
+            @defaultOpen={{this.showAdvancedFilters}}
             @iconOpen="nav-up"
             @iconClosed="nav-down"
             @buttonLabel="Geavanceerde filters"
@@ -183,7 +183,7 @@
               @placeholder="Alle bestuursorganen"
             />
 
-          </AuAccordion>
+          </Accordion>
         </section>
       </div>
       <div class="c-interface__sidebar-submit-buttons">

--- a/tests/integration/components/accordion-test.js
+++ b/tests/integration/components/accordion-test.js
@@ -1,0 +1,26 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import { module, test } from 'qunit';
+
+module('Integration | Component | accordion', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should show the content when defaultOpen is true', async function (assert) {
+    this.set('defaultOpen', true);
+    await render(hbs`<Accordion @defaultOpen={{this.defaultOpen}} >
+      <h1>Accordion content</h1>
+    </Accordion>`);
+
+    assert.dom('h1').exists();
+  });
+
+  test('it should not show the content when defaultOpen is false', async function (assert) {
+    this.set('defaultOpen', false);
+    await render(hbs`<Accordion @defaultOpen={{this.defaultOpen}} >
+      <h1>Accordion content</h1>
+    </Accordion>`);
+
+    assert.dom('h1').doesNotExist();
+  });
+});


### PR DESCRIPTION
# BNB-490

## What?
I've made it so that when a user picks a governing body classification and returns they will still see an open advanced filter accordion. This also works when navigating to the page through a link.

## Why?
This change is more in line with the expected behaviour comparable to how searching on a title or keyword goes. See [BNB-490](https://binnenland.atlassian.net/browse/BNB-490?atlOrigin=eyJpIjoiOTdmY2M5NTg5YmMwNDM4ODhlNmE3ODczZjFkYjdhM2YiLCJwIjoiaiJ9) for more information.

## How?
As the current iteration of Appuniverse does not support a way to open an accordion through an argument.
This means that I had to create a seperate `<Accordion/>` component based off of the `<AuAccordion/>` but with an `@defaultOpen={{bool}}` argument to set the default state of the accordion.

## Testing?
I've added coverage to whether or not content gets rendered inside of the accordion component when `@defaultOpen={{bool}}` is set to either true/false.

## Screenshots
**Before**
<img width="667" alt="Screenshot 2024-01-17 at 3 35 04 PM" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/1740ba8b-0227-46e2-b6e4-f85c6e73064b">

**After**
<img width="667" alt="Screenshot 2024-01-17 at 3 35 11 PM" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/efdc10ea-1fc0-4412-a825-47753aeda1c6">
