### PR TITLE
Add resolution title as fallback + mu-search improvements

### DIFF
--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -270,6 +270,7 @@ type AgendaItemMuSearchEntry = {
   session_ended_at?: string;
   title?: string;
   description?: string;
+  resolution_title?: string;
 };
 
 type AgendaItemsQueryResult = PageableRequest<
@@ -373,6 +374,9 @@ const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (
   // Map data attributes to AgendaItem properties
   dataResponse.id = Array.isArray(uuid) ? uuid[0] : uuid;
   dataResponse.title = cleanString(parseMuSearchAttributeToString(entry.title));
+  dataResponse.resolutionTitle = cleanString(
+    parseMuSearchAttributeToString(entry.resolution_title)
+  );
   dataResponse.description = cleanString(
     parseMuSearchAttributeToString(entry.description)
   );

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -313,27 +313,21 @@ const agendaItemsQuery = ({
   if (locationIds) {
     filters[':terms:search_location_id'] = locationIds;
   }
+
+  // Apply optional filter for governing body ids
   if (governingBodyClassificationIds) {
-    const queryIds = governingBodyClassificationIds
-      .split(',')
-      .map((id) => `(governing_body_classification_id:${id})`)
-      .join(' OR ');
-    filters[':query:governing_body_classification_id'] = queryIds;
+    filters[':terms:search_governing_body_classification_id'] =
+      governingBodyClassificationIds;
   }
 
   // Apply optional filter for keyword search
   if (keyword) {
-    filters[
-      ':query:title'
-    ] = `(title:*${keyword}*) OR (description:*${keyword}*)`;
+    filters[':fuzzy:search_content'] = keyword;
   }
 
   // Apply optional filter for date sorting
-  if (dateSort === 'asc') {
-    request.sort = `+session_planned_start`;
-  } else {
-    request.sort = '-session_planned_start';
-  }
+  const order = dateSort === 'asc' ? '+' : '-';
+  request.sort = `${order}session_planned_start`;
 
   // Set page size and filters in the request
   request.page = page;

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -296,9 +296,8 @@ const agendaItemsQuery = ({
 
   request.index = index;
 
-  // Ensure title and location_id fields are present
-  filters[':query:title'] =
-    '_exists_:title AND (_exists_:location_id OR _exists_:abstract_location_id)';
+  // Ensure search_location_id field is present
+  filters[':has:search_location_id'] = 't';
 
   // Apply optional filter for planned start range
   if (plannedStartMin) {

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -88,8 +88,8 @@ class AgendaItemsLoader extends Resource<AgendaItemsLoaderArgs> {
 
       const municipalityIds =
         await this.municipalityList.getLocationIdsFromLabels(
-        this.#filters.municipalityLabels
-      );
+          this.#filters.municipalityLabels
+        );
 
       const provinceIds = await this.provinceList.getProvinceIdsFromLabels(
         this.#filters.provinceLabels
@@ -267,6 +267,8 @@ type AgendaItemMuSearchEntry = {
   governing_body_location_name?: string;
   abstract_governing_body_name?: string;
   governing_body_name?: string;
+  abstract_governing_body_classification_name?: string;
+  governing_body_classification_name?: string;
   session_planned_start?: string;
   session_started_at?: string;
   session_ended_at?: string;
@@ -366,6 +368,13 @@ const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (
   );
   dataResponse.governingBodyName = parseMuSearchAttributeToString(
     entry.governing_body_name
+  );
+  dataResponse.abstractGoverningBodyClassificationName =
+    parseMuSearchAttributeToString(
+      entry.abstract_governing_body_classification_name
+    );
+  dataResponse.governingBodyClassificationName = parseMuSearchAttributeToString(
+    entry.governing_body_classification_name
   );
   dataResponse.sessionPlannedStart = parseMuSearchAttributeToDate(
     entry.session_planned_start

--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -49,7 +49,7 @@ export default class SessionsIndexController extends Controller {
           nextPage,
           this.plannedStartMin,
           this.plannedStartMax,
-          locationIds
+          locationIds.join(',')
         )
       )) as unknown as Session[];
 

--- a/app/models/mu-search/agenda-item.ts
+++ b/app/models/mu-search/agenda-item.ts
@@ -13,6 +13,7 @@ export default class AgendaItemModel {
   declare sessionEndedAt?: Date;
   declare title?: string;
   declare description?: string;
+  declare resolutionTitle?: string;
 
   get dateFormatted() {
     if (this.sessionStartedAt || this.sessionEndedAt) {
@@ -30,6 +31,10 @@ export default class AgendaItemModel {
       this.governingBodyName ||
       'Ontbrekend bestuursorgaan'
     );
+  }
+
+  get titleResolved() {
+    return this.title || this.resolutionTitle || 'Ontbrekende titel';
   }
 
   get municipality() {

--- a/app/models/mu-search/agenda-item.ts
+++ b/app/models/mu-search/agenda-item.ts
@@ -8,6 +8,8 @@ export default class AgendaItemModel {
   declare governingBodyLocationName?: string;
   declare abstractGoverningBodyName?: string;
   declare governingBodyName?: string;
+  declare abstractGoverningBodyClassificationName?: string;
+  declare governingBodyClassificationName?: string;
   declare sessionPlannedStart?: Date;
   declare sessionStartedAt?: Date;
   declare sessionEndedAt?: Date;
@@ -25,10 +27,10 @@ export default class AgendaItemModel {
 
     return 'Geen Datum';
   }
-  get governingBodyNameResolved() {
+  get governingBodyClassificationNameResolved() {
     return (
-      this.abstractGoverningBodyName ||
-      this.governingBodyName ||
+      this.abstractGoverningBodyClassificationName ||
+      this.governingBodyClassificationName ||
       'Ontbrekend bestuursorgaan'
     );
   }

--- a/app/routes/sessions/index.ts
+++ b/app/routes/sessions/index.ts
@@ -93,7 +93,7 @@ export default class SessionsIndexRoute extends Route {
           currentPage,
           this.plannedStartMin,
           this.plannedStartMax,
-          locationIds
+          locationIds.join(',')
         )
       );
 

--- a/app/services/municipality-list.ts
+++ b/app/services/municipality-list.ts
@@ -94,26 +94,24 @@ export default class MunicipalityListService extends Service {
    *
    * @param labels an array of location labels
    *               Alternatively, a string of location labels
-   * @param stringSeperator the seperator to split labels, if labels is a string
-   *                        Defaults to the seperator defined in helpers/constants.ts
-   * @returns a Promise for a joined string of those locations' id's, or undefined
+   * @returns a Promise for an array of location ids
    */
   async getLocationIdsFromLabels(
     labels?: Array<string> | string
-  ): Promise<string | undefined> {
+  ): Promise<Array<string>> {
     const municipalities = await this.municipalities();
     if (typeof labels === 'string') {
       labels = deserializeArray(labels);
     }
 
     if (!labels || !municipalities) {
-      return undefined;
+      return [];
     }
 
     const locationIds: Array<string> = municipalities
       .filter(({ label }) => labels?.includes(label))
       .map(({ id }) => id);
 
-    return locationIds.join(',');
+    return locationIds;
   }
 }

--- a/app/services/province-list.ts
+++ b/app/services/province-list.ts
@@ -22,17 +22,17 @@ export default class ProvinceListService extends Service {
 
   async getProvinceIdsFromLabels(
     labels: Array<string> | string
-  ): Promise<string | undefined> {
+  ): Promise<Array<string>> {
     const provinces = await this.provinces();
     if (!labels || labels.length === 0) {
-      return;
+      return [];
     }
 
     const provinceIds = provinces
       .filter((province) => labels.includes(province.label))
       .map(({ id }) => id);
 
-    return provinceIds.join(',');
+    return provinceIds;
   }
 
   private async _loadProvinces() {

--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -101,7 +101,7 @@
                   <li>
                     <AgendaItemCard
                       @id={{item.id}}
-                      @title={{item.title}}
+                      @title={{item.titleResolved}}
                       @description={{item.description}}
                       @date={{item.dateFormatted}}
                       @governingBodyName={{item.governingBodyNameResolved}}

--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -104,7 +104,7 @@
                       @title={{item.titleResolved}}
                       @description={{item.description}}
                       @date={{item.dateFormatted}}
-                      @governingBodyName={{item.governingBodyNameResolved}}
+                      @governingBodyName={{item.governingBodyClassificationNameResolved}}
                       @municipality={{item.municipality}}
                     />
                   </li>

--- a/tests/unit/services/municipality-list-test.js
+++ b/tests/unit/services/municipality-list-test.js
@@ -71,12 +71,9 @@ module('Unit | Service | municipality-list', function (hooks) {
     const service = this.subject();
     const ids = await service.getLocationIdsFromLabels('Aalter');
 
-    assert.strictEqual(
-      ids,
-      [
-        '7a7daa48e9e6449358cf96be6c7b30466648d31236e56b8958fae7d53e2308b8',
-        'a0e4508a-a20b-42e5-a40d-4d919d045fdd',
-      ].join()
-    );
+    assert.deepEqual(ids, [
+      '7a7daa48e9e6449358cf96be6c7b30466648d31236e56b8958fae7d53e2308b8',
+      'a0e4508a-a20b-42e5-a40d-4d919d045fdd',
+    ]);
   });
 });


### PR DESCRIPTION
Related to BNB-473 and BNB-401

What was done: 
- Use resolution title as fallback in agenda-item list page
- Only keep location_id as required in filtering, title is not required anymore
- Simplify municipality and province filtering
- Use new `search_*` fields add in https://github.com/lblod/app-burgernabije-besluitendatabank/pull/69 to simplify filtering
- Use governing body classification name instead of governing body name in result page

## Before
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/fde012a8-526a-4fb2-b1a7-ed9b96099a8e)

## After
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/feee833a-f8dd-4fe7-b4f0-b32d63a8db5d)
