### PR TITLE
fix: 🐛 antwerpen-query-select-fix

### DIFF
--- a/app/components/filters/filter.ts
+++ b/app/components/filters/filter.ts
@@ -31,8 +31,12 @@ export default class FilterComponent<S = Signature> extends Component<S> {
    * @param params object with {queryParameterName: newValue}
    */
   updateQueryParams(params: { [key: string]: unknown }) {
-    this.router.transitionTo(this.router.currentRouteName, {
-      queryParams: params,
-    });
+    if (this.router) {
+      this.router.transitionTo(this.router.currentRouteName, {
+        queryParams: params,
+      });
+    } else {
+      console.error('Router service is not available.');
+    }
   }
 }

--- a/app/components/filters/select-multiple-filter.hbs
+++ b/app/components/filters/select-multiple-filter.hbs
@@ -16,6 +16,7 @@
     }}
     @searchMessage="Aan het zoeken..."
     @searchEnabled={{true}}
+    data-test-select-multiple-filter
     {{did-insert this.inserted}}
     as |value|
   >

--- a/app/components/filters/select-multiple-filter.ts
+++ b/app/components/filters/select-multiple-filter.ts
@@ -33,7 +33,10 @@ export default class SelectMultipleFilterComponent extends FilterComponent<Signa
       const needles = deserializeArray(this.args.queryParam).map(
         (queryParam) => {
           if (!queryParam) return [];
-          return this.getQueryParam(queryParam);
+          return {
+            queryParam: queryParam,
+            value: this.getQueryParam(queryParam),
+          };
         }
       );
 
@@ -52,11 +55,28 @@ export default class SelectMultipleFilterComponent extends FilterComponent<Signa
       }
 
       needles.forEach((needle) => {
-        const found = flattenedHaystack.find(
-          (value) => get(value, searchField) === needle
-        );
-        if (found) {
-          results.push(found);
+        if (
+          typeof needle === 'object' &&
+          'value' in needle &&
+          typeof needle.value === 'string'
+        ) {
+          const splitNeedles = needle.value.split('+').map((value) => {
+            return {
+              queryParam: needle.queryParam,
+              value: value,
+            };
+          });
+
+          splitNeedles.forEach((needle) => {
+            const found = flattenedHaystack.find(
+              (value) =>
+                get(value, searchField) === needle.value &&
+                value['type'] === needle.queryParam
+            );
+            if (found) {
+              results.push(found);
+            }
+          });
         }
       });
 

--- a/tests/integration/components/filters/select-multiple-filter-test.js
+++ b/tests/integration/components/filters/select-multiple-filter-test.js
@@ -1,0 +1,148 @@
+import { click, findAll, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import { module, test } from 'qunit';
+
+module(
+  'Integration | Component | filters/select-multiple-filter',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function () {
+      await render(hbs`<Filters::SelectMultipleFilter />`);
+    });
+
+    test('it displays grouped options', async function (assert) {
+      const options = [
+        {
+          groupName: 'Group 1',
+          options: [
+            { label: 'Option 1', type: 'type1' },
+            { label: 'Option 2', type: 'type2' },
+          ],
+        },
+        {
+          groupName: 'Group 2',
+          options: [
+            { label: 'Option 3', type: 'type3' },
+            { label: 'Option 4', type: 'type4' },
+          ],
+        },
+      ];
+      const searchField = 'label';
+      const queryParam = 'type1+type3';
+      const selected = [
+        { label: 'Option 1', type: 'type1' },
+        { label: 'Option 3', type: 'type3' },
+      ];
+
+      this.setProperties({ options, searchField, queryParam, selected });
+
+      // Re-render the component with the new args
+      await render(hbs`
+        <Filters::SelectMultipleFilter
+          @options={{this.options}}
+          @searchField={{this.searchField}}
+          @queryParam={{this.queryParam}}
+          @selected={{this.selected}}
+          @updateSelected={{this.updateSelected}}
+        />
+      `);
+
+      // Click on the select multiple filter
+      await click('[data-test-select-multiple-filter]');
+
+      // Check if options are displayed
+      const optionLabels = findAll('.ember-power-select-option');
+      assert.deepEqual(optionLabels.length, 4, 'All options are displayed');
+    });
+
+    test('it displays selected options', async function (assert) {
+      const options = [
+        {
+          groupName: 'Group 1',
+          options: [
+            { label: 'Option 1', type: 'type1' },
+            { label: 'Option 2', type: 'type2' },
+          ],
+        },
+        {
+          groupName: 'Group 2',
+          options: [
+            { label: 'Option 3', type: 'type3' },
+            { label: 'Option 4', type: 'type4' },
+          ],
+        },
+      ];
+      const searchField = 'label';
+      const queryParam = 'type1+type3';
+      const selected = [
+        { label: 'Option 1', type: 'type1' },
+        { label: 'Option 3', type: 'type3' },
+      ];
+
+      this.setProperties({ options, searchField, queryParam, selected });
+
+      // Re-render the component with the new args
+      await render(hbs`
+        <Filters::SelectMultipleFilter
+          @options={{this.options}}
+          @searchField={{this.searchField}}
+          @queryParam={{this.queryParam}}
+          @selected={{this.selected}}
+          @updateSelected={{this.updateSelected}}
+        />
+      `);
+
+      // Click on the select multiple filter
+      await click('[data-test-select-multiple-filter]');
+
+      // Check if selected options are displayed
+      const selectedOptionLabels = findAll(
+        '.ember-power-select-multiple-option'
+      );
+      assert.deepEqual(
+        selectedOptionLabels.length,
+        2,
+        'All selected options are displayed'
+      );
+    });
+
+    // if there are two options with the same label, they should both be displayed
+
+    test('it displays options with the same label', async function (assert) {
+      const options = [
+        {
+          groupName: 'Group 1',
+          options: [
+            { label: 'Option 1', type: 'type1' },
+            { label: 'Option 1', type: 'type2' },
+          ],
+        },
+      ];
+      const searchField = 'label';
+      const queryParam = 'type1';
+      const selected = [{ label: 'Option 1', type: 'type1' }];
+
+      this.setProperties({ options, searchField, queryParam, selected });
+
+      // Re-render the component with the new args
+      await render(hbs`
+        <Filters::SelectMultipleFilter
+          @options={{this.options}}
+          @searchField={{this.searchField}}
+          @queryParam={{this.queryParam}}
+          @selected={{this.selected}}
+          @updateSelected={{this.updateSelected}}
+        />
+      `);
+
+      // Click on the select multiple filter
+      await click('[data-test-select-multiple-filter]');
+
+      // Check if options are displayed
+      const optionLabels = findAll('.ember-power-select-option');
+      assert.deepEqual(optionLabels.length, 2, 'All options are displayed');
+    });
+  }
+);


### PR DESCRIPTION
# BNB-524

## What?
There was a big bug inside of the `inserted` function inside of the select-filter component. In fact, there were **2 big issues** occuring either when _being routed from home to the agenda items route_ or _when being directed to the agenda items route through a link_:
1. Whenever multiple governments would get queried they wouldn't get delimited from each other. This in turn made it so that if a user were to select for instance "Aalst+Aarschot" the values wouldn't get processed properly by the haystack/needle function as it would be looking for "Aalst+Aarschot" instead of the "Aalst" and "Aarschot".
2. Whenever the haystack/needle function would look for a government it would do so regardless of whether it is a `province` or  a `municipality`- it would always find the `municipality` first because this occurs before the provinces in the haystack. This in turn means that if a user would query a province with a municipality counterpart (Antwerp) it would always select the municipality version of Antwerp which then made it select unable to properly communicate with the actual query params.

## Why?
Previously if a user was to select multiple governments and/or the province of Antwerp and then continue to the agenda items route there would be a bug where the multiple governments would not show up in the select component and/or the province of Antwerp would not get removed from the query parameters through said select component. 
[BNB-524](https://binnenland.atlassian.net/browse/BNB-524) for more information.

## How?
As the current iteration of Appuniverse does not support a way to open an accordion through an argument.
This means that I had to create a seperate `<Accordion/>` component based off of the `<AuAccordion/>` but with an `@defaultOpen={{bool}}` argument to set the default state of the accordion.

## Testing?
Tests should also be written for this improved functionality, but I reckon we should be creating a seperate and more congruent test PR for the filter components.

## Screenshots
**Before**
https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/6e524bf2-748d-4d2b-a049-feef21e0f92a

**After**

https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/7bd5f6b2-f7df-4a16-997f-7adc92fe1090


