### PR TITLE
feat: :sparkles: added multiselect functionality to the classification select

### DIFF
--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -177,6 +177,16 @@ export default class AgendaItemsIndexController extends Controller {
     this.dateSort = event?.target?.value;
   }
 
+  @action updateSelectedGoverningBodyClassifications(
+    newOptions: Array<{
+      label: string;
+      id: string;
+      type: 'governing-body-classifications';
+    }>
+  ) {
+    this.governingBodyList.selectedGoverningBodyClassifications = newOptions;
+  }
+
   @tracked dateSort = 'desc';
 
   /** Controls the loading animation of the "load more" button */

--- a/app/services/governing-body-list.ts
+++ b/app/services/governing-body-list.ts
@@ -1,5 +1,6 @@
 import Store from '@ember-data/store';
 import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class GoverningBodyListService extends Service {
   @service declare store: Store;
@@ -16,12 +17,15 @@ export default class GoverningBodyListService extends Service {
       return undefined;
     }
 
+    console.log(governingBodyLabels);
+
     const governingBodies = await this.governingBodies();
 
     const governingBodyLabelsArray = Array.isArray(governingBodyLabels)
       ? governingBodyLabels
-      : governingBodyLabels.split('+');
+      : governingBodyLabels.split(',');
 
+    console.log(governingBodyLabelsArray);
     const governingBodyClassificationIds = governingBodies.reduce(
       (acc, governingBody) => {
         if (governingBodyLabelsArray.includes(governingBody.label)) {
@@ -34,6 +38,12 @@ export default class GoverningBodyListService extends Service {
 
     return governingBodyClassificationIds.join(',');
   }
+
+  @tracked selectedGoverningBodyClassifications: Array<{
+    label: string;
+    id: string;
+    type: 'governing-body-classifications';
+  }> = [];
 
   async governingBodies() {
     const governingBodyClasssificationCodes = await this.store.query(

--- a/app/services/governing-body-list.ts
+++ b/app/services/governing-body-list.ts
@@ -17,15 +17,11 @@ export default class GoverningBodyListService extends Service {
       return undefined;
     }
 
-    console.log(governingBodyLabels);
-
     const governingBodies = await this.governingBodies();
 
     const governingBodyLabelsArray = Array.isArray(governingBodyLabels)
       ? governingBodyLabels
       : governingBodyLabels.split(',');
-
-    console.log(governingBodyLabelsArray);
     const governingBodyClassificationIds = governingBodies.reduce(
       (acc, governingBody) => {
         if (governingBodyLabelsArray.includes(governingBody.label)) {

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -356,3 +356,9 @@ cursor {
     padding-top: $au-unit-tiny * 0.3;
   }
 }
+
+#governing-body {
+  ul {
+    margin: 0 0.6rem;
+  }
+}

--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -172,9 +172,10 @@
             @iconClosed="nav-down"
             @buttonLabel="Geavanceerde filters"
           >
-            <Filters::SelectFilter
-              @value={{this.governingBodyClassifications}}
-              @id="governingBody"
+            <Filters::SelectMultipleFilter
+              @selected={{this.governingBodyList.selectedGoverningBodyClassifications}}
+              @updateSelected={{this.updateSelectedGoverningBodyClassifications}}
+              @id="governing-body"
               @label="Kies één of meer bestuursorganen"
               @noMatchesMessage="Geen bestuursorganen gevonden"
               @options={{this.governingBodies}}


### PR DESCRIPTION
# BNB-525

## What?
Updating the government body classification logic to mimic the logic used in location.

## Why?
In order to keep the logic coherent as far as UX/UI users should also be able to select multiple classifications as they do governments.
[BNB-525](https://binnenland.atlassian.net/browse/BNB-525) for more information.

## How?
Upgrading the single select to a multi select.

## Testing?
The testing for this should be covered by the general filter tests.

## Screenshots
Before 

https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/8629f1c1-dad7-4c66-8fbc-4c691ef7133d

After

https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/23e1d6c4-f83b-4328-80df-c968859147a2





