### PR TITLE
refactored inserted logic

### DIFF
--- a/app/components/filters/select-multiple-filter.ts
+++ b/app/components/filters/select-multiple-filter.ts
@@ -45,14 +45,19 @@ export default class SelectMultipleFilterComponent extends FilterComponent<Signa
 
     if (this.isGroupedOptions(haystack)) {
       haystack.forEach((group: GroupedOptions) => {
-        group.options.forEach((option: Option) => {
-          flattenedHaystack.push(option);
-        });
+        if (group.options) {
+          group.options.forEach((option: Option) => {
+            flattenedHaystack.push(option);
+          });
+        }
       });
-    } else {
+    } else if (Array.isArray(haystack)) {
       haystack.forEach((option: Option) => {
         flattenedHaystack.push(option);
       });
+    } else {
+      console.error('Unexpected format for options:', haystack);
+      return;
     }
 
     const results = deserializeArray(this.args.queryParam).flatMap(
@@ -61,6 +66,7 @@ export default class SelectMultipleFilterComponent extends FilterComponent<Signa
         const queryParamValue = this.getQueryParam(queryParam);
         const values = queryParamValue ? deserializeArray(queryParamValue) : [];
         return values
+          .flatMap((value) => value.split(','))
           .map((value) => {
             return flattenedHaystack.find(
               (option) =>


### PR DESCRIPTION
# BNB-555
(rework of BNB-522)

## What?
Refactored the way the inserted() logic works.

## Why?
Sometimes when users would go back to a previous page they would encounter a bug where the advanced filters section was closed even though it contained an active filter as well as there'd be no classification value filled in.
[BNB-555](https://binnenland.atlassian.net/browse/BNB-555) for more information.

## How?
Stop checking on ["type"] for entries without it. Also fill the flattenedHaystack when there are no groups.