### PR TITLE
Session mu-search

### DIFF
--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -1,67 +1,374 @@
 import Controller from '@ember/controller';
-import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import SessionIndexRoute from '../../routes/sessions/index';
-import { ModelFrom } from '../../lib/type-utils';
 import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
-import Session from 'frontend-burgernabije-besluitendatabank/models/session';
+import Session from 'frontend-burgernabije-besluitendatabank/models/mu-search/session';
+import MuSearchService, {
+  DataMapper,
+  MuSearchData,
+  MuSearchResponse,
+  PageableRequest,
+} from 'frontend-burgernabije-besluitendatabank/services/mu-search';
+import { task } from 'ember-concurrency';
+import { Resource } from 'ember-resources';
+import GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
+import GovernmentListService from 'frontend-burgernabije-besluitendatabank/services/government-list';
+import ProvinceListService from 'frontend-burgernabije-besluitendatabank/services/province-list';
+import {
+  parseMuSearchAttributeToString,
+  parseMuSearchAttributeToDate,
+} from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
+import RouterService from '@ember/routing/router-service';
+
+interface SessionsParams {
+  municipalityLabels: string;
+  provinceLabels: string;
+  plannedStartMin: string;
+  plannedStartMax: string;
+  governingBodyClassifications: string;
+  dataQualityList: Array<string>;
+  dateSort: string;
+}
+
+interface SessionsLoaderArgs {
+  Named: {
+    filters: SessionsParams;
+  };
+}
+
+class SessionsLoader extends Resource<SessionsLoaderArgs> {
+  @service declare municipalityList: MunicipalityListService;
+  @service declare provinceList: ProvinceListService;
+  @service declare governingBodyList: GoverningBodyListService;
+  @service declare governmentList: GovernmentListService;
+  @service declare muSearch: MuSearchService;
+
+  @tracked data: Session[] = [];
+  @tracked total = 0;
+
+  #currentPage = 0;
+  #filters?: SessionsParams;
+
+  get canLoadMore() {
+    return this.data.length < this.total;
+  }
+
+  get hasResults() {
+    return this.data.length > 0;
+  }
+
+  get isLoading() {
+    return this.loadSessions.isRunning;
+  }
+
+  get hasErrored() {
+    return this.loadSessions.last?.isError;
+  }
+
+  modify(positional: unknown[], named: SessionsLoaderArgs['Named']) {
+    this.#filters = named.filters;
+    this.#loadInitialData();
+  }
+
+  #loadInitialData() {
+    this.#reset();
+    this.loadSessions.perform(this.#currentPage);
+  }
+
+  // We can't use private (#) fields here because it conflicts with the ember-concurrency task transpiler
+  private loadSessions = task({ restartable: true }, async (page: number) => {
+    if (!this.#filters) {
+      return;
+    }
+
+    const municipalityIds =
+      await this.municipalityList.getLocationIdsFromLabels(
+        this.#filters.municipalityLabels
+      );
+
+    const provinceIds = await this.provinceList.getProvinceIdsFromLabels(
+      this.#filters.provinceLabels
+    );
+
+    const locationIds = [...municipalityIds, ...provinceIds].join(',');
+
+    const { plannedStartMin, plannedStartMax, dateSort } = this.#filters;
+
+    const governingBodyClassificationIds =
+      await this.governingBodyList.getGoverningBodyClassificationIdsFromLabels(
+        this.#filters.governingBodyClassifications
+      );
+
+    const sessions: MuSearchResponse<Session> = await this.muSearch.search(
+      sessionsQuery({
+        index: 'sessions',
+        page,
+        locationIds,
+        governingBodyClassificationIds,
+        plannedStartMin,
+        plannedStartMax,
+        dateSort,
+      })
+    );
+
+    this.total = sessions.count ?? 0;
+    this.data = [...this.data, ...sessions.items.slice()];
+  });
+
+  #reset() {
+    this.#currentPage = 0;
+    this.data = [];
+    this.total = 0;
+  }
+
+  loadMore = () => {
+    if (this.canLoadMore) {
+      this.#currentPage += 1;
+      this.loadSessions.perform(this.#currentPage);
+    }
+  };
+}
 
 export default class SessionsIndexController extends Controller {
-  @service declare store: Store;
   @service declare municipalityList: MunicipalityListService;
+  @service declare provinceList: ProvinceListService;
+  @service declare governingBodyList: GoverningBodyListService;
+  @service declare governmentList: GovernmentListService;
 
-  /** Used to request more data */
-  declare model: ModelFrom<SessionIndexRoute>;
+  @action
+  updateSelectedGovernment(
+    newOptions: Array<{
+      label: string;
+      id: string;
+      type: 'provincies' | 'gemeentes';
+    }>
+  ) {
+    this.governmentList.selectedLocalGovernments = newOptions;
+  }
+
+  get localGovernmentGroupOptions() {
+    return Promise.all([this.municipalities, this.provinces]).then(
+      ([municipalities, provinces]) => [
+        { groupName: 'Gemeente', options: municipalities },
+        { groupName: 'Provincie', options: provinces },
+      ]
+    );
+  }
+  // QueryParameters
+  @tracked municipalityLabels = '';
+  @tracked provinceLabels = '';
+  @tracked plannedStartMin = '';
+  @tracked plannedStartMax = '';
+  @tracked keyword = '';
+  @tracked governingBodyClassifications = '';
+
+  @service declare router: RouterService;
+
+  get showAdvancedFilters() {
+    return this.governingBodyClassifications.length > 0;
+  }
+
+  @action handleDateSortChange(event: { target: { value: string } }) {
+    this.dateSort = event?.target?.value;
+  }
+
+  @action updateSelectedGoverningBodyClassifications(
+    newOptions: Array<{
+      label: string;
+      id: string;
+      type: 'governing-body-classifications';
+    }>
+  ) {
+    this.governingBodyList.selectedGoverningBodyClassifications = newOptions;
+  }
+
+  @tracked dateSort = 'desc';
 
   /** Controls the loading animation of the "load more" button */
   @tracked isLoadingMore = false;
 
-  @tracked sessions: Session[] = [];
+  @tracked loading = false; // Controls the loading animation that replaces the main view
+  @tracked errorMsg = ''; // Controls whether an Oops is shown
 
-  plannedStartMin?: string;
-  plannedStartMax?: string;
-  municipalityLabels?: string;
+  /** Mobile filter */
+  @tracked hasFilter = false;
+
+  /** Data quality modal */
+  @tracked modalOpen = false;
+
+  SessionsLoader = SessionsLoader;
 
   get municipalities() {
     return this.municipalityList.municipalityLabels();
   }
 
-  setup() {
-    this.sessions = this.model.sessions.slice();
+  get provinces() {
+    return this.provinceList.provinceLabels();
+  }
+  get governingBodies() {
+    return this.governingBodyList.governingBodies();
   }
 
-  @action
-  async loadMore() {
-    //todo add max page guard
-    if (this.model && !this.isLoadingMore) {
-      this.isLoadingMore = true;
-      const nextPage = this.model.currentPage + 1;
+  updateKeyword = (value: string) => {
+    this.router.transitionTo('agenda-items', {
+      queryParams: { trefwoord: value },
+    });
+  };
 
-      const locationIds = await this.municipalityList.getLocationIdsFromLabels(
-        this.municipalityLabels
-      );
+  showFilter = () => {
+    this.hasFilter = true;
+  };
 
-      const sessions = (await this.store.query(
-        'session',
-        this.model.getQuery(
-          nextPage,
-          this.plannedStartMin,
-          this.plannedStartMax,
-          locationIds.join(',')
-        )
-      )) as unknown as Session[];
-
-      this.sessions = [...this.sessions, ...sessions];
-
-      this.model.currentPage = nextPage;
-      this.isLoadingMore = false;
+  hideFilter = () => {
+    if (this.hasFilter) {
+      this.hasFilter = false;
     }
+  };
+
+  showModal = () => {
+    this.modalOpen = true;
+  };
+
+  closeModal = () => {
+    if (this.modalOpen) {
+      this.modalOpen = false;
+    }
+  };
+
+  get filters(): SessionsParams {
+    return {
+      municipalityLabels: this.municipalityLabels,
+      provinceLabels: this.provinceLabels,
+      plannedStartMin: this.plannedStartMin,
+      plannedStartMax: this.plannedStartMax,
+      dateSort: this.dateSort,
+      governingBodyClassifications: this.governingBodyClassifications,
+      dataQualityList: [],
+    };
   }
 
-  get isEmpty() {
-    console.log('isEmpty', this.model.sessions.length);
-    return this.model.sessions.length === 0;
+  get hasMunicipalityFilter() {
+    return this.filters.municipalityLabels.length > 0;
   }
 }
+
+type SessionsQueryArguments = {
+  index: string;
+  page: number;
+  keyword?: string;
+  locationIds?: string;
+  provinceIds?: string;
+  plannedStartMin?: string;
+  plannedStartMax?: string;
+  dateSort?: string;
+  governingBodyClassificationIds?: string;
+};
+
+type SessionMuSearchEntry = {
+  uuid: string[] | string;
+  abstract_location_id?: string;
+  location_id?: string;
+  abstract_governing_body_location_name?: string;
+  governing_body_location_name?: string;
+  abstract_governing_body_name?: string;
+  governing_body_name?: string;
+  abstract_governing_body_classification_name?: string;
+  governing_body_classification_name?: string;
+  planned_start?: string;
+  started_at?: string;
+  ended_at?: string;
+  title?: string;
+  description?: string;
+  resolution_title?: string;
+  'agenda-items_id'?: string[];
+};
+
+type SessionsQueryResult = PageableRequest<SessionMuSearchEntry, Session>;
+
+const sessionsQuery = ({
+  index,
+  page,
+  plannedStartMin,
+  plannedStartMax,
+  dateSort,
+  locationIds,
+  governingBodyClassificationIds,
+}: SessionsQueryArguments): SessionsQueryResult => {
+  // Initialize filters and request objects
+  const filters = {} as { [key: string]: string };
+  const request: PageableRequest<SessionMuSearchEntry, Session> =
+    {} as PageableRequest<SessionMuSearchEntry, Session>;
+
+  request.index = index;
+
+  // Ensure search_location_id field is present
+  filters[':has:search_location_id'] = 't';
+
+  // Apply optional filter for planned start range
+  if (plannedStartMin) {
+    filters[':query:planned_start'] = `(planned_start:[${plannedStartMin} TO ${
+      plannedStartMax || '*'
+    }] ) `;
+  }
+
+  // Apply optional filter for locationIds
+  if (locationIds) {
+    filters[':terms:search_location_id'] = locationIds;
+  }
+
+  // Apply optional filter for governing body ids
+  if (governingBodyClassificationIds) {
+    filters[':terms:search_governing_body_classification_id'] =
+      governingBodyClassificationIds;
+  }
+
+  // Apply optional filter for date sorting
+  const order = dateSort === 'asc' ? '+' : '-';
+  request.sort = `${order}planned_start`;
+
+  // Set page size and filters in the request
+  request.page = page;
+  request.size = 10;
+  request.filters = filters;
+
+  // Set dataMapping function in the request
+  request.dataMapping = dataMapping;
+  return request;
+};
+
+const dataMapping: DataMapper<SessionMuSearchEntry, Session> = (
+  data: MuSearchData<SessionMuSearchEntry>
+) => {
+  const entry = data.attributes;
+  const uuid = entry.uuid;
+  const dataResponse = new Session();
+
+  // Map data attributes to AgendaItem properties
+  dataResponse.id = Array.isArray(uuid) ? uuid[0] : uuid;
+  dataResponse.locationId = entry.location_id || entry.abstract_location_id;
+  dataResponse.abstractGoverningBodyLocationName =
+    parseMuSearchAttributeToString(entry.abstract_governing_body_location_name);
+  dataResponse.governingBodyLocationName = parseMuSearchAttributeToString(
+    entry.governing_body_location_name
+  );
+  dataResponse.abstractGoverningBodyName = parseMuSearchAttributeToString(
+    entry.abstract_governing_body_name
+  );
+  dataResponse.governingBodyName = parseMuSearchAttributeToString(
+    entry.governing_body_name
+  );
+  dataResponse.agendaItemsId = entry['agenda-items_id'] || [];
+  dataResponse.abstractGoverningBodyClassificationName =
+    parseMuSearchAttributeToString(
+      entry.abstract_governing_body_classification_name
+    );
+  dataResponse.governingBodyClassificationName = parseMuSearchAttributeToString(
+    entry.governing_body_classification_name
+  );
+  dataResponse.plannedStart = parseMuSearchAttributeToDate(entry.planned_start);
+  dataResponse.endedAt = parseMuSearchAttributeToDate(entry.ended_at);
+  dataResponse.startedAt = parseMuSearchAttributeToDate(entry.started_at);
+
+  return dataResponse;
+};

--- a/app/models/mu-search/session.ts
+++ b/app/models/mu-search/session.ts
@@ -1,0 +1,48 @@
+import { getFormattedDate } from 'frontend-burgernabije-besluitendatabank/utils/get-formatted-date';
+import { getFormattedDateRange } from 'frontend-burgernabije-besluitendatabank/utils/get-formatted-date-range';
+
+export default class SessionModel {
+  declare id?: string;
+  declare locationId?: string;
+  declare abstractGoverningBodyLocationName?: string;
+  declare governingBodyLocationName?: string;
+  declare abstractGoverningBodyName?: string;
+  declare governingBodyName?: string;
+  declare abstractGoverningBodyClassificationName?: string;
+  declare governingBodyClassificationName?: string;
+  declare plannedStart?: Date;
+  declare startedAt?: Date;
+  declare endedAt?: Date;
+  declare agendaItemsId: Array<string>;
+
+  get dateFormatted() {
+    if (this.startedAt && this.endedAt) {
+      return getFormattedDateRange(this.startedAt, this.endedAt);
+    }
+    if (this.plannedStart) {
+      return 'gepland op ' + getFormattedDate(this.plannedStart);
+    }
+
+    return 'Geen Datum';
+  }
+
+  get agendaItemCount() {
+    return this.agendaItemsId.length;
+  }
+
+  get governingBodyClassificationNameResolved() {
+    return (
+      this.abstractGoverningBodyClassificationName ||
+      this.governingBodyClassificationName ||
+      'Ontbrekend bestuursorgaan'
+    );
+  }
+
+  get municipality() {
+    return (
+      this.abstractGoverningBodyLocationName ||
+      this.governingBodyLocationName ||
+      'Ontbrekende bestuurseenheid'
+    );
+  }
+}

--- a/app/routes/sessions/index.ts
+++ b/app/routes/sessions/index.ts
@@ -1,118 +1,32 @@
-import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
-import Transition from '@ember/routing/transition';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
-import SessionsIndexController from 'frontend-burgernabije-besluitendatabank/controllers/sessions';
-import SessionModel from 'frontend-burgernabije-besluitendatabank/models/session';
-import MunicipalityListService from 'frontend-burgernabije-besluitendatabank/services/municipality-list';
-import {
-  AdapterPopulatedRecordArrayWithMeta,
-  getCount,
-} from 'frontend-burgernabije-besluitendatabank/utils/ember-data';
-
-interface sessionsIndexParams {
-  plannedStartMin?: string;
-  plannedStartMax?: string;
-  municipalityLabels?: string;
-}
-
-/** Generate Ember Data options to fetch more sessions based on the passed filters */
-const getQuery = (
-  page: number,
-  plannedStartMin?: string,
-  plannedStartMax?: string,
-  locationIds?: string
-) => ({
-  filter: {
-    'governing-body': {
-      'is-time-specialization-of': {
-        'administrative-unit': {
-          location: {
-            ':id:': locationIds ? locationIds : undefined,
-          },
-        },
-      },
-    },
-    ':gt:planned-start': plannedStartMin ? plannedStartMin : undefined,
-    ':lt:planned-start': plannedStartMax ? plannedStartMax : undefined,
-  },
-  include: [
-    'governing-body.is-time-specialization-of.administrative-unit.location',
-    'governing-body.administrative-unit.location',
-    'agenda-items',
-  ].join(','),
-  sort: '-planned-start',
-  page: {
-    number: page,
-  },
-});
+import QueryParameterKeys from 'frontend-burgernabije-besluitendatabank/constants/query-parameter-keys';
+import FeaturesService from 'frontend-burgernabije-besluitendatabank/services/features';
 
 export default class SessionsIndexRoute extends Route {
-  @service declare store: Store;
-  @service declare municipalityList: MunicipalityListService;
+  @service declare features: FeaturesService;
 
   queryParams = {
     municipalityLabels: {
-      as: 'gemeentes',
-      refreshModel: true,
+      as: QueryParameterKeys.municipalities,
+    },
+    provinceLabels: {
+      as: QueryParameterKeys.provinces,
+    },
+    governingBodyClassifications: {
+      as: QueryParameterKeys.governingBodies,
     },
     plannedStartMin: {
-      as: 'begin',
-      refreshModel: true,
+      as: QueryParameterKeys.start,
     },
     plannedStartMax: {
-      as: 'eind',
-      refreshModel: true,
+      as: QueryParameterKeys.end,
+    },
+    keyword: {
+      as: QueryParameterKeys.keyword,
+    },
+    dateSort: {
+      as: QueryParameterKeys.dateSort,
     },
   };
-
-  // QueryParams
-  @tracked municipalityLabels?: string;
-  @tracked plannedStartMin?: string;
-  @tracked plannedStartMax?: string;
-
-  async model(params: sessionsIndexParams) {
-    this.plannedStartMin = params.plannedStartMin;
-    this.plannedStartMax = params.plannedStartMax || undefined;
-    this.municipalityLabels = params.municipalityLabels || '';
-
-    /**
-     * Municipalities transform
-     *
-     */
-    const locationIds = await this.municipalityList.getLocationIdsFromLabels(
-      this.municipalityLabels
-    );
-
-    const currentPage = 0;
-    const sessions: AdapterPopulatedRecordArrayWithMeta<SessionModel> =
-      await this.store.query(
-        'session',
-        getQuery(
-          currentPage,
-          this.plannedStartMin,
-          this.plannedStartMax,
-          locationIds.join(',')
-        )
-      );
-
-    const count = getCount(sessions);
-
-    return {
-      sessions,
-      currentPage: currentPage,
-      getQuery,
-      count,
-    };
-  }
-
-  setupController(
-    controller: SessionsIndexController,
-    model: unknown,
-    transition: Transition<unknown>
-  ): void {
-    super.setupController(controller, model, transition);
-    controller.setup();
-  }
 }

--- a/app/templates/sessions/index.hbs
+++ b/app/templates/sessions/index.hbs
@@ -1,62 +1,207 @@
-{{page-title "Zittingen"}}
-
 <AuBodyContainer>
   <div class="c-interface">
-    <div class="c-interface__content c-interface__content--fixed">
-      {{#if this.isEmpty}}
-        <AuAlert
-          @size="small"
-          @skin="warning"
-          @icon="info-circle"
-          @title="Er werden geen zoekresultaten gevonden."
-        />
-      {{else}}
-        <InfiniteList
-          @loadMore={{this.loadMore}}
-          @isLoading={{this.isLoadingMore}}
-          @itemsShown={{this.sessions.length}}
-          @itemsAmount={{@model.count}}
+    <div
+      id="filtercontent"
+      class="c-interface__content c-interface__content--fixed au-u-flex au-u-flex--column"
+    >
+      <div class="au-o-flow au-o-flow--small au-u-padding">
+        <AuHeading @level="1" @skin="2">Wat zoek je?</AuHeading>
+        <div
+          class="au-u-flex au-u-flex--between au-u-1-1 au-u-flex--column@small"
         >
-          {{#each this.sessions as |session|}}
-            <li>
-              <article class="c-agenda-item-card">
-                <AuHeading @level="1" @skin="5">
-                  <AuLink
-                    @route="sessions.session"
-                    @model={{session.id}}
-                    class="c-agenda-item-card__link"
+          <Filters::TextFilter
+            @id="keyword"
+            @route="agenda-items"
+            @class="au-u-max-width-xsmall@small"
+            @queryParam="trefwoord"
+            @value={{this.keyword}}
+            @label="Zoeken"
+            @labelHidden={{true}}
+            @placeholder="Zoek in alle lokale agendapunten"
+            @buttonText="Zoeken"
+            @icon="search"
+            @rowClass="au-c-form-row--button"
+          />
+
+          <AuFormRow
+            @alignment="inline"
+            class="au-u-1-1 au-u-flex au-u-flex--end au-u-margin-top-small@xsmall au-u-margin-top-none@small"
+          >
+            <section
+              class="au-u-flex au-u-1-2@large au-u-1-1 au-u-margin-left-small@small au-u-flex--end"
+            >
+              <AuLabel for="sort-on" class="au-u-hidden-visually" />
+              <select
+                id="sort-on"
+                type="select"
+                {{on "change" this.handleDateSortChange}}
+                class="au-c-input au-u-1-2@small au-u-1-1 au-u-max-width-xsmall@small"
+              >
+                <option value="desc">Sorteer van nieuw naar oud</option>
+                <option value="asc">
+                  Sorteer van oud naar nieuw
+                </option>
+              </select>
+            </section>
+          </AuFormRow>
+
+        </div>
+        <a href="#filtersidebar" class="au-c-interface__filter-link">
+          Ga naar filters
+        </a>
+        <a
+          href="#filtersidebar"
+          class="au-c-button au-c-button--secondary au-c-button--block c-interface__filter-button"
+          {{on "click" this.showFilter}}
+        >
+          <AuIcon @icon="filter" />
+          Toon filters
+        </a>
+      </div>
+      {{#let (this.SessionsLoader filters=this.filters) as |loader|}}
+        {{#if loader.hasErrored}}
+          <Oops @title="Oeps!" @content="Er is iets fout gelopen!" />
+        {{else}}
+          {{#if (and loader.isLoading (not loader.hasResults))}}
+            <LoaderFullPage @content="Zittingen aan het laden" />
+          {{else}}
+            {{#if loader.hasResults}}
+              {{#if loader.total}}
+                <div
+                  class="au-u-flex au-u-flex--vertical-center au-u-flex--between"
+                >
+                  <p
+                    class="au-u-margin-left au-u-margin-top-small au-u-h4 au-u-medium"
                   >
-                    {{session.governingBodyNameResolved}}
-                    {{session.dateFormatted}}
-                  </AuLink>
-                </AuHeading>
-                <div class="c-agenda-item-card__footer">
-                  {{session.municipality}}
-                  -
-                  {{session.agendaItemCount}}
+                    {{loader.total}}
+                    {{#if (eq loader.total 1)}}
+                      Zitting
+                    {{else}}
+                      Zittingen
+                    {{/if}}
+                  </p>
                 </div>
-              </article>
-            </li>
-          {{/each}}
-        </InfiniteList>
-      {{/if}}
+              {{/if}}
+
+              <InfiniteList
+                @loadMore={{loader.loadMore}}
+                @isLoading={{loader.isLoading}}
+                @itemsShown={{loader.data.length}}
+                @itemsAmount={{loader.total}}
+              >
+                {{#each loader.data as |item|}}
+                  <li>
+                    <article class="c-agenda-item-card">
+                      <AuHeading @level="1" @skin="5">
+                        <AuLink
+                          @route="sessions.session"
+                          @model={{item.id}}
+                          class="c-agenda-item-card__link"
+                        >
+                          {{item.governingBodyClassificationNameResolved}}
+                          {{item.dateFormatted}}
+                        </AuLink>
+                      </AuHeading>
+                      <div class="c-agenda-item-card__footer">
+                        {{item.municipality}}
+                        -
+                        {{item.agendaItemCount}}
+                        agendapunten
+                      </div>
+                    </article>
+                  </li>
+                {{/each}}
+              </InfiniteList>
+            {{else}}
+              <div class="au-o-box">
+                <AuAlert
+                  @size="small"
+                  @skin="warning"
+                  @icon="info-circle"
+                  @title="Er werden geen zoekresultaten gevonden."
+                />
+              </div>
+            {{/if}}
+          {{/if}}
+        {{/if}}
+      {{/let}}
     </div>
-    <FilterSidebar @class="c-interface__sidebar au-o-flow">
-      <h3 class="au-u-h4 au-u-medium">Verfijn de zoekresultaten</h3>
-      <Filters::SelectMultipleFilter
-        @id="municipality"
-        @label="Kies één of meer gemeentes"
-        @options={{this.municipalities}}
-        @searchField="label"
-        @queryParam="gemeentes"
-        @placeholder="Alle gemeentes"
-      />
-      <Filters::DateRangeFilter
-        @startQueryParam="begin"
-        @endQueryParam="eind"
-        @start={{this.plannedStartMin}}
-        @end={{this.plannedStartMax}}
-      />
+    <FilterSidebar
+      @id="filtersidebar"
+      @class="c-interface__sidebar c-interface__sidebar--dialog {{if
+        this.hasFilter
+        'is-visible'
+      }}"
+      {{focus-trap
+        isActive=this.hasFilter
+        shouldSelfFocus=true
+        additionalElements=(array "#ember-basic-dropdown-wormhole")
+        focusTrapOptions=(hash onDeactivate=this.hideFilter)
+      }}
+    >
+      <div class="c-interface__sidebar-close-button">
+        <a
+          href="#filtercontent"
+          class="au-c-button au-c-button--naked"
+          {{on "click" this.hideFilter}}
+        >
+          Terug
+        </a>
+      </div>
+      <div class="c-interface__sidebar-main">
+        <h3 class="au-u-h4 au-u-medium">Verfijn de zoekresultaten</h3>
+        <Filters::SelectMultipleFilter
+          @id="municipality"
+          @label="Kies één of meer besturen"
+          @options={{this.localGovernmentGroupOptions}}
+          @selected={{this.governmentList.selectedLocalGovernments}}
+          @updateSelected={{this.updateSelectedGovernment}}
+          @noMatchesMessage="Geen besturen gevonden"
+          @searchField="label"
+          @queryParam="gemeentes+provincies"
+          @placeholder="Alle besturen"
+        />
+        <Filters::DateRangeFilter
+          @startQueryParam="begin"
+          @endQueryParam="eind"
+          @start={{this.plannedStartMin}}
+          @end={{this.plannedStartMax}}
+        />
+        <section class="c-advanced-filter-holder">
+          <Accordion
+            @defaultOpen={{this.showAdvancedFilters}}
+            @iconOpen="nav-up"
+            @iconClosed="nav-down"
+            @buttonLabel="Geavanceerde filters"
+          >
+            <Filters::SelectMultipleFilter
+              @selected={{this.governingBodyList.selectedGoverningBodyClassifications}}
+              @updateSelected={{this.updateSelectedGoverningBodyClassifications}}
+              @id="governing-body"
+              @label="Kies één of meer bestuursorganen"
+              @noMatchesMessage="Geen bestuursorganen gevonden"
+              @options={{this.governingBodies}}
+              @searchField="label"
+              @queryParam="bestuursorganen"
+              @placeholder="Alle bestuursorganen"
+            />
+
+          </Accordion>
+        </section>
+      </div>
+      <div class="c-interface__sidebar-submit-buttons">
+        <AuButton @skin="primary" @width="block" {{on "click" this.hideFilter}}>
+          Zoeken
+        </AuButton>
+
+        <a
+          href="#filtercontent"
+          class="au-c-button au-c-button--naked au-c-button--block"
+          {{on "click" this.hideFilter}}
+        >
+          Annuleer
+        </a>
+      </div>
     </FilterSidebar>
   </div>
 </AuBodyContainer>


### PR DESCRIPTION
# BNB-551

## What?
This PR is about updating the sessions to use mu-search like the agenda items. Previously, sessions were using resources, which was inconsistent with the rest of the application.

## Why?
The main reason for this change is to bring consistency across the application. By using mu-search for sessions, we align the search functionality with that of the agenda items. This will make the codebase more maintainable and improve the user experience by providing consistent search results.

## How?
The changes were made by updating the session service to use mu-search instead of resources. The necessary adjustments were made to the query parameters and the response handling to accommodate this change.

## Screenshots

Before
https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/61a5e391-d97c-40a6-9450-1931bb9e1d70


After
https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/d4b238da-3905-4a23-855c-d38c6f1466b9


For more information, please refer to the ticket [BNB-551](https://binnenland.atlassian.net/browse/BNB-551).