### PR TITLE
Display agendaItem without title in session page

### DIFF
--- a/app/components/session.hbs
+++ b/app/components/session.hbs
@@ -14,7 +14,7 @@
                 @route="agenda-items.agenda-item"
                 @model={{item.id}}
               >
-                {{item.title}}
+                {{item.titleFormatted}}
               </AuLink>
             </AuHeading>
             <p class="c-agenda-item-card__content">{{item.description}}</p>

--- a/app/controllers/sessions/session.ts
+++ b/app/controllers/sessions/session.ts
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { ModelFrom } from '../../lib/type-utils';
 import SessionSessionRoute from '../../routes/sessions/session';
-import { sortObjectsByTitle } from 'frontend-burgernabije-besluitendatabank/utils/array-utils';
 import AgendaItem from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
 
 export default class SessionsSessionController extends Controller {
@@ -19,7 +18,11 @@ export default class SessionsSessionController extends Controller {
 
     return agendaItems
       .slice()
-      .filter(({ title }) => !!title)
-      .sort(sortObjectsByTitle);
+      .filter(({ titleFormatted }) => !!titleFormatted)
+      .sort((a, b) =>
+        a.titleFormatted.localeCompare(b.titleFormatted, undefined, {
+          numeric: true,
+        })
+      );
   }
 }

--- a/app/routes/sessions/session.ts
+++ b/app/routes/sessions/session.ts
@@ -10,7 +10,7 @@ export default class SessionRoute extends Route {
       include: [
         'governing-body.is-time-specialization-of.administrative-unit.location',
         'governing-body.administrative-unit.location',
-        'agenda-items',
+        'agenda-items.handled-by.resolutions',
       ].join(','),
     });
   }


### PR DESCRIPTION
## Context

In session detail page, we filter out agendaitem without title.

## Proposal

Use resolution title as fallback, like in other part than the application. 

## Before
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/fe4b33db-501a-4717-853b-be89f1c85693)

## After
![image](https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/3050307/85e7237c-fc37-4541-a1fb-6240e5feda6d)
