### PR TITLE
Multiple sources + detail redesign

### DIFF
--- a/app/models/agenda-item.ts
+++ b/app/models/agenda-item.ts
@@ -14,7 +14,7 @@ import SessionModel from './session';
 export default class AgendaItemModel extends Model {
   @attr('string') declare title: string;
   @attr('string') declare description: string;
-  @attr('string') declare alternateLink: string;
+  @attr('string') declare alternateLink: string[];
   @attr('boolean') declare plannedPublic: boolean;
 
   @hasMany('session', { async: true, inverse: 'agendaItems' })

--- a/app/models/agenda-item.ts
+++ b/app/models/agenda-item.ts
@@ -14,7 +14,7 @@ import SessionModel from './session';
 export default class AgendaItemModel extends Model {
   @attr('string') declare title: string;
   @attr('string') declare description: string;
-  @attr('string') declare alternateLink: string[];
+  @attr() declare alternateLink: string[];
   @attr('boolean') declare plannedPublic: boolean;
 
   @hasMany('session', { async: true, inverse: 'agendaItems' })

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -12,6 +12,13 @@ iframe[name*="JSD widget"] {
   justify-content: end;
 }
 
+.truncate {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .graph-bar-text {
   position: absolute;
   left: 0;

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -38,25 +38,6 @@
               <AuHeading @level="1" @skin="3">
                 {{this.model.agendaItem.titleFormatted}}
               </AuHeading>
-              <p class="au-u-margin-left@large au-u-margin-top-tiny">
-                <AuPill
-                  @skin="warning"
-                  class="au-c-pill--hover au-u-word-nowrap"
-                  {{on "click" this.showModal}}
-                >
-                  <svg
-                    role="img"
-                    aria-hidden="true"
-                    class="au-c-icon"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                  ><path
-                      fill-rule="evenodd"
-                      d="M19,1 L13,1 C11.897,1 11,1.898 11,3 L11,21 C11,22.103 11.897,23 13,23 L19,23 C20.103,23 21,22.103 21,21 L21,3 C21,1.898 20.103,1 19,1 Z M13,21 L13,18 L16,18 L16,16 L13,16 L13,13 L16,13 L16,11 L13,11 L13,8 L16,8 L16,6 L13,6 L13,3 L19,3 L19.001,21 L13,21 Z M3,7 C3,5.346 4.346,4 6,4 C7.654,4 9,5.346 9,7 L9,18.303 L6,22.803 L3,18.303 L3,7 Z M6,19.197 L7,17.697 L7,10 L5,10 L5,17.697 L6,19.197 Z M5,8 L5,7 C5,6.448 5.449,6 6,6 C6.551,6 7,6.448 7,7 L7,8 L5,8 Z"
-                    /></svg>
-                  Datakwaliteit
-                </AuPill>
-              </p>
             </div>
           </c.header>
           <c.content class="content">
@@ -207,46 +188,102 @@
             </section>
           </c.content>
         </AuCard>
-        {{#if this.model.agendaItemOnSameSession}}
-          <AuCard class="au-u-margin-top" as |c|>
-            <c.header>
-              <h2 class="au-u-h4 au-u-medium">
-                Volledige agenda van
-                {{this.model.agendaItem.session.dateFormatted}}
-              </h2>
-            </c.header>
-            <c.content>
-              {{#if this.model.agendaItemOnSameSession}}
-                <ol>
-                  {{#each this.model.agendaItemOnSameSession as |agendaItem|}}
-                    <li>
-                      {{! if the agendaItem.id is equal to the current agendaItem then display "Huidige agendapunt" }}
-                      {{#if (eq agendaItem.id this.model.agendaItem.id)}}
-                        <p class="au-u-medium">Huidige agendapunt</p>
-                      {{else}}
-                        <AuLink
-                          @route="agenda-items.agenda-item"
-                          @model={{agendaItem.id}}
-                        >
-                          {{agendaItem.titleFormatted}}
-                        </AuLink>
-                      {{/if}}
-                    </li>
-                  {{/each}}
-                </ol>
-              {{/if}}
-            </c.content>
-            <c.footer>
-              <AuLink
-                @skin="button"
-                @route="agenda-items.session"
-                @model="{{this.model.agendaItem.id}}"
+        <AuCard class="au-u-margin-top" as |c|>
+          <c.header>
+            <div class="au-u-flex au-u-flex--between au-u-flex--column@small">
+              <AuHeading @level="1" @skin="3">
+                Bronnen &amp; kwaliteit
+              </AuHeading>
+            </div>
+          </c.header>
+          <c.content class="content">
+            {{#if this.model.agendaItem.alternateLink}}
+              <div
+                class="au-u-flex au-u-flex--vertical-center au-u-flex--spaced-tiny"
               >
-                Volledige agenda
-              </AuLink>
-            </c.footer>
-          </AuCard>
-        {{/if}}
+                <svg
+                  role="img"
+                  aria-hidden="true"
+                  class="au-c-icon au-c-icon--large"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                ><path
+                    fill-rule="evenodd"
+                    d="M19,1 L13,1 C11.897,1 11,1.898 11,3 L11,21 C11,22.103 11.897,23 13,23 L19,23 C20.103,23 21,22.103 21,21 L21,3 C21,1.898 20.103,1 19,1 Z M13,21 L13,18 L16,18 L16,16 L13,16 L13,13 L16,13 L16,11 L13,11 L13,8 L16,8 L16,6 L13,6 L13,3 L19,3 L19.001,21 L13,21 Z M3,7 C3,5.346 4.346,4 6,4 C7.654,4 9,5.346 9,7 L9,18.303 L6,22.803 L3,18.303 L3,7 Z M6,19.197 L7,17.697 L7,10 L5,10 L5,17.697 L6,19.197 Z M5,8 L5,7 C5,6.448 5.449,6 6,6 C6.551,6 7,6.448 7,7 L7,8 L5,8 Z"
+                  /></svg>
+                Bronnen
+              </div>
+              <div class="au-c-content">
+                <AuList @divider={{true}} as |Item|>
+                  {{#each
+                    this.model.agendaItem.alternateLink
+                    as |alternateLink|
+                  }}
+                    <Item>
+                      {{#if alternateLink}}
+                        <AuBadge @icon="check" @skin="success" @size="small" />
+                        <p class="au-u-flex--inline">
+                          {{alternateLink}}
+                          is aanwezig
+                        </p>
+                      {{/if}}
+                    </Item>
+                  {{/each}}
+                </AuList>
+              </div>
+            {{/if}}
+            <div
+              class="au-u-flex au-u-flex--vertical-center au-u-flex--spaced-tiny"
+            >
+              <svg
+                role="img"
+                aria-hidden="true"
+                class="au-c-icon au-c-icon--large"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+              ><path
+                  fill-rule="evenodd"
+                  d="M19,1 L13,1 C11.897,1 11,1.898 11,3 L11,21 C11,22.103 11.897,23 13,23 L19,23 C20.103,23 21,22.103 21,21 L21,3 C21,1.898 20.103,1 19,1 Z M13,21 L13,18 L16,18 L16,16 L13,16 L13,13 L16,13 L16,11 L13,11 L13,8 L16,8 L16,6 L13,6 L13,3 L19,3 L19.001,21 L13,21 Z M3,7 C3,5.346 4.346,4 6,4 C7.654,4 9,5.346 9,7 L9,18.303 L6,22.803 L3,18.303 L3,7 Z M6,19.197 L7,17.697 L7,10 L5,10 L5,17.697 L6,19.197 Z M5,8 L5,7 C5,6.448 5.449,6 6,6 C6.551,6 7,6.448 7,7 L7,8 L5,8 Z"
+                /></svg>
+              Datakwaliteit
+            </div>
+            <div class="au-c-content">
+              <AuHeading @level="2" @skin="4">Aanwezige elementen op deze pagina</AuHeading>
+              <AuList @divider={{true}} as |Item|>
+
+                {{#each
+                  this.model.agendaItem.agendaItemQualityMetrics
+                  as |qualityMetric|
+                }}
+                  <Item>
+                    {{#if qualityMetric.value}}
+                      <AuBadge @icon="check" @skin="success" @size="small" />
+                      <p class="au-u-flex--inline">
+                        {{qualityMetric.label}}
+                        is aanwezig
+                      </p>
+                    {{else}}
+                      <AuBadge @icon="cross" @skin="error" @size="small" />
+                      <p class="au-u-flex--inline">
+                        {{qualityMetric.label}}
+                        is niet aanwezig
+                      </p>
+                    {{/if}}
+                  </Item>
+                {{/each}}
+              </AuList>
+            </div>
+            <div class="au-c-content au-c-content--small">
+              <p>Om na te gaan of besturen voldoen aan de gelinkte
+                publicatieplicht, heeft ABB enkel gekeken naar de webtoepassing
+                waarop besturen gelinkte publicaties publiceren. Enkel de
+                documenten die gelinkt gepubliceerd zijn en automatisch van de
+                webtoepassing gehaald konden worden, zijn verder bekeken.</p>
+              <p><AuLink @route="data-quality">Meer informatie over de data
+                  kwaliteit</AuLink></p>
+            </div>
+          </c.content>
+        </AuCard>
       </article>
       <aside class="au-o-grid__item au-u-2-6@medium">
         <div class="u-top-sticky">
@@ -266,6 +303,40 @@
             )
           }}
             <AuContent class="au-u-margin-top">
+              {{#if this.model.agendaItemOnSameSession}}
+                <h2 class="au-u-h4 au-u-medium">
+                  <AuLink
+                    class="au-u-medium"
+                    @route="agenda-items.session"
+                    @model="{{this.model.agendaItem.id}}"
+                  >
+                    Volledige agenda
+                  </AuLink>
+                  van
+                  {{this.model.agendaItem.session.dateFormatted}}
+                </h2>
+                {{#if this.model.agendaItemOnSameSession}}
+                  <ol>
+                    {{#each this.model.agendaItemOnSameSession as |agendaItem|}}
+                      <li>
+                        {{! if the agendaItem.id is equal to the current agendaItem then display "Huidige agendapunt" }}
+                        {{#if (eq agendaItem.id this.model.agendaItem.id)}}
+                          <p class="au-u-medium">Huidige agendapunt</p>
+                        {{else}}
+                          <AuLink
+                            @route="agenda-items.agenda-item"
+                            @model={{agendaItem.id}}
+                          >
+                            <p class="truncate">
+                              {{agendaItem.titleFormatted}}
+                            </p>
+                          </AuLink>
+                        {{/if}}
+                      </li>
+                    {{/each}}
+                  </ol>
+                {{/if}}
+              {{/if}}
               <AuHeading @level="2" @skin="4">
                 {{#if this.keywordStore.keyword}}
                   Meer relevante info over
@@ -289,7 +360,9 @@
                       @model={{agendaItem.id}}
                       @route="agenda-items.agenda-item"
                     >
-                      {{agendaItem.titleFormatted}}
+                      <p class="truncate">
+                        {{agendaItem.titleFormatted}}
+                      </p>
                     </AuLink>
                   </li>
                 {{/each}}
@@ -301,64 +374,3 @@
     </div>
   </div>
 </div>
-
-{{! Data quality modal }}
-<AuModal
-  @modalOpen={{this.modalOpen}}
-  @closeModal={{this.closeModal}}
-  @size="default"
->
-  <:title>
-    <div class="au-u-flex au-u-flex--vertical-center au-u-flex--spaced-tiny">
-      <svg
-        role="img"
-        aria-hidden="true"
-        class="au-c-icon au-c-icon--large"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-      ><path
-          fill-rule="evenodd"
-          d="M19,1 L13,1 C11.897,1 11,1.898 11,3 L11,21 C11,22.103 11.897,23 13,23 L19,23 C20.103,23 21,22.103 21,21 L21,3 C21,1.898 20.103,1 19,1 Z M13,21 L13,18 L16,18 L16,16 L13,16 L13,13 L16,13 L16,11 L13,11 L13,8 L16,8 L16,6 L13,6 L13,3 L19,3 L19.001,21 L13,21 Z M3,7 C3,5.346 4.346,4 6,4 C7.654,4 9,5.346 9,7 L9,18.303 L6,22.803 L3,18.303 L3,7 Z M6,19.197 L7,17.697 L7,10 L5,10 L5,17.697 L6,19.197 Z M5,8 L5,7 C5,6.448 5.449,6 6,6 C6.551,6 7,6.448 7,7 L7,8 L5,8 Z"
-        /></svg>
-      Datakwaliteit
-    </div>
-  </:title>
-  <:body>
-    <div class="au-c-content">
-      <AuHeading @level="2" @skin="4">Ontbrekende elementen op deze pagina</AuHeading>
-      <AuList @divider={{true}} as |Item|>
-
-        {{#each
-          this.model.agendaItem.agendaItemQualityMetrics
-          as |qualityMetric|
-        }}
-          <Item>
-            {{#if qualityMetric.value}}
-              <AuBadge @icon="check" @skin="success" @size="small" />
-              <p class="au-u-flex--inline">
-                {{qualityMetric.label}}
-                is aanwezig
-              </p>
-            {{else}}
-              <AuBadge @icon="cross" @skin="error" @size="small" />
-              <p class="au-u-flex--inline">
-                {{qualityMetric.label}}
-                is niet aanwezig
-              </p>
-            {{/if}}
-          </Item>
-        {{/each}}
-      </AuList>
-    </div>
-  </:body>
-  <:footer>
-    <div class="au-c-content au-c-content--small">
-      <p>Om na te gaan of besturen voldoen aan de gelinkte publicatieplicht,
-        heeft ABB enkel gekeken naar de webtoepassing waarop besturen gelinkte
-        publicaties publiceren. Enkel de documenten die gelinkt gepubliceerd
-        zijn en automatisch van de webtoepassing gehaald konden worden, zijn
-        verder bekeken.</p>
-      <p><AuLink @route="data-quality">Meer informatie over de data kwaliteit</AuLink></p>
-    </div>
-  </:footer>
-</AuModal>

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -201,19 +201,13 @@
               <div
                 class="au-u-flex au-u-flex--vertical-center au-u-flex--spaced-tiny"
               >
-                <svg
-                  role="img"
-                  aria-hidden="true"
-                  class="au-c-icon au-c-icon--large"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                ><path
-                    fill-rule="evenodd"
-                    d="M19,1 L13,1 C11.897,1 11,1.898 11,3 L11,21 C11,22.103 11.897,23 13,23 L19,23 C20.103,23 21,22.103 21,21 L21,3 C21,1.898 20.103,1 19,1 Z M13,21 L13,18 L16,18 L16,16 L13,16 L13,13 L16,13 L16,11 L13,11 L13,8 L16,8 L16,6 L13,6 L13,3 L19,3 L19.001,21 L13,21 Z M3,7 C3,5.346 4.346,4 6,4 C7.654,4 9,5.346 9,7 L9,18.303 L6,22.803 L3,18.303 L3,7 Z M6,19.197 L7,17.697 L7,10 L5,10 L5,17.697 L6,19.197 Z M5,8 L5,7 C5,6.448 5.449,6 6,6 C6.551,6 7,6.448 7,7 L7,8 L5,8 Z"
-                  /></svg>
-                Bronnen
+                <AuHeading @level="2" @skin="4">
+                  Bronnen
+                </AuHeading>
               </div>
               <div class="au-c-content">
+                <p>De gemeente heeft dit agendapunt vermeld op de volgende
+                  URL's:</p>
                 <AuList @divider={{true}} as |Item|>
                   {{#each
                     this.model.agendaItem.alternateLink
@@ -221,11 +215,12 @@
                   }}
                     <Item>
                       {{#if alternateLink}}
-                        <AuBadge @icon="check" @skin="success" @size="small" />
-                        <p class="au-u-flex--inline">
+                        <AuLinkExternal
+                          href={{alternateLink}}
+                          class="au-u-flex--inline"
+                        >
                           {{alternateLink}}
-                          is aanwezig
-                        </p>
+                        </AuLinkExternal>
                       {{/if}}
                     </Item>
                   {{/each}}
@@ -235,20 +230,12 @@
             <div
               class="au-u-flex au-u-flex--vertical-center au-u-flex--spaced-tiny"
             >
-              <svg
-                role="img"
-                aria-hidden="true"
-                class="au-c-icon au-c-icon--large"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-              ><path
-                  fill-rule="evenodd"
-                  d="M19,1 L13,1 C11.897,1 11,1.898 11,3 L11,21 C11,22.103 11.897,23 13,23 L19,23 C20.103,23 21,22.103 21,21 L21,3 C21,1.898 20.103,1 19,1 Z M13,21 L13,18 L16,18 L16,16 L13,16 L13,13 L16,13 L16,11 L13,11 L13,8 L16,8 L16,6 L13,6 L13,3 L19,3 L19.001,21 L13,21 Z M3,7 C3,5.346 4.346,4 6,4 C7.654,4 9,5.346 9,7 L9,18.303 L6,22.803 L3,18.303 L3,7 Z M6,19.197 L7,17.697 L7,10 L5,10 L5,17.697 L6,19.197 Z M5,8 L5,7 C5,6.448 5.449,6 6,6 C6.551,6 7,6.448 7,7 L7,8 L5,8 Z"
-                /></svg>
-              Datakwaliteit
+              <AuHeading @level="2" @skin="4">
+                Datakwaliteit
+              </AuHeading>
             </div>
             <div class="au-c-content">
-              <AuHeading @level="2" @skin="4">Aanwezige elementen op deze pagina</AuHeading>
+              <p>Aanwezige elementen op deze pagina:</p>
               <AuList @divider={{true}} as |Item|>
 
                 {{#each

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -90,17 +90,6 @@
                 <span class="au-u-hidden-visually">Planning:</span>
                 {{this.model.agendaItem.session.dateFormatted}}
               </li>
-              {{#if this.model.agendaItem.alternateLink}}
-                <li>
-                  <AuIcon @size="large" @icon="link" />
-                  <span class="au-u-hidden-visually">Externe link</span>
-                  <AuLinkExternal
-                    href="{{this.model.agendaItem.alternateLink}}"
-                  >
-                    Bekijk agendapunt op de publicatieomgeving van de gemeente
-                  </AuLinkExternal>
-                </li>
-              {{/if}}
             </ul>
             <AuContent @skin="small">
               <p class="au-u-muted">


### PR DESCRIPTION
# BNB-315

## What?
Redesigning the agenda item page + adding the multiple sources instead of just displaying one source.

## Why?
In order to properly display agenda item sources we had to rearrange the current design.

## Screenshots

Before

<img width="1512" alt="Screenshot 2024-03-13 at 14 48 47" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/9db4a4a6-ef4f-4ee1-8f1b-bdf5c288eda1">
<img width="1512" alt="Screenshot 2024-03-13 at 14 48 55" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/e57c0972-6fa6-4045-b73d-d0439266176e">


After

<img width="1512" alt="Screenshot 2024-03-13 at 14 48 11" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/7fb2d4b1-3e19-4f3b-98da-d68b7dec6e01">
<img width="1512" alt="Screenshot 2024-03-13 at 14 48 18" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/16b24c12-1469-4dba-b8b8-8ccbdbbc019a">


For more information, please refer to the ticket [BNB-315](https://binnenland.atlassian.net/browse/BNB-315).