### PR TITLE
Future dates in date picker

### DIFF
--- a/app/components/filters/date-range-filter.ts
+++ b/app/components/filters/date-range-filter.ts
@@ -26,6 +26,7 @@ interface Signature {
 }
 
 enum Preset {
+  Future = 'Toekomst',
   ThisWeek = 'Deze week',
   LastWeek = 'Vorige week',
   ThisMonth = 'Deze maand',
@@ -49,6 +50,7 @@ export default class DateRangeFilterComponent extends Component<Signature> {
   @tracked startDateError?: string[];
 
   presets = [
+    Preset.Future,
     Preset.ThisWeek,
     Preset.LastWeek,
     Preset.ThisMonth,
@@ -61,6 +63,7 @@ export default class DateRangeFilterComponent extends Component<Signature> {
   get presetDateRanges() {
     const today = new Date();
     return {
+      [Preset.Future]: [toIsoDateString(today), this.MAX],
       [Preset.ThisWeek]: [
         toIsoDateString(startOfWeek(today)),
         toIsoDateString(endOfWeek(today)),

--- a/app/routes/agenda-items/agenda-item.ts
+++ b/app/routes/agenda-items/agenda-item.ts
@@ -35,7 +35,6 @@ export default class AgendaItemRoute extends Route {
         await administrativeUnit?.location;
       }) || []
     );
-
     const sessionId = agendaItem.session?.id;
     const agendaItemOnSameSessionRaw = sessionId
       ? await this.store.query('agenda-item', {


### PR DESCRIPTION
# BNB-292

## What?
Added a **future** option to the date picker component.

## Why?
There was no easy way and user-friendly for users to filter on future dates.

## Screenshots

Before

<img width="1511" alt="image" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/6217389e-c993-4c61-8043-aedf3d9a3fe6">

After

<img width="1511" alt="image" src="https://github.com/lblod/frontend-burgernabije-besluitendatabank/assets/50323795/1c2265ec-2ae7-4bd2-a240-99e30187d484">

For more information, please refer to the ticket [BNB-292](https://binnenland.atlassian.net/browse/BNB-292).