### PR TITLE
Add a way to disable governing body via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Or in template files by using the `is-feature-enabled` helper:
 
 ### Disabling governing bodies
 
-Time to time, it might be necessary to disable certain governing bodies. This can be done by setting the `GOVERNING_BODY_DISABLED_LIST` environment variable. The value should be a comma-separated list of URIs of the governing bodies that should be disabled.
+Time to time, it might be necessary to disable certain governing bodies. This can be done by setting the `GOVERNING_BODY_DISABLED_LIST` environment variable. The value should be a comma-separated list of `mu:uuid` of the governing bodies that should be disabled. The agenda items related to the disabled governing bodies will not be accessible in the application.
 
 ### styles/ naming scheme
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ Or in template files by using the `is-feature-enabled` helper:
 | ----------------- | --------------------------------------------------------------- |
 | PLAUSIBLE_APIHOST | The domain where the plausible.js can be found                  |
 | PLAUSIBLE_DOMAIN  | The domain that has been configured to be tracked. If undefined |
+| GOVERNING_BODY_DISABLED_LIST | A comma-separated list of governing bodies that should be disabled |
+
+### Disabling governing bodies
+
+Time to time, it might be necessary to disable certain governing bodies. This can be done by setting the `GOVERNING_BODY_DISABLED_LIST` environment variable. The value should be a comma-separated list of URIs of the governing bodies that should be disabled.
 
 ### styles/ naming scheme
 

--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -14,6 +14,7 @@ declare const config: {
     domain: string;
   };
   features: Record<string, boolean | string>;
+  'governing-body-disabled': string;
 };
 
 export default config;

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -124,10 +124,6 @@ class AgendaItemsLoader extends Resource<AgendaItemsLoaderArgs> {
 
       // remove disabled governing bodies from the response
       const items = agendaItems.items.filter((item) => {
-        console.log(
-          'item.governingBodyClassificationName',
-          item.governingBodyClassificationName
-        );
         return !this.governingBodyDisabledList.disabledList.some((disabled) =>
           item.governingBodyIdResolved.includes(disabled)
         );
@@ -231,7 +227,6 @@ export default class AgendaItemsIndexController extends Controller {
   }
 
   updateKeyword = (value: string) => {
-    console.log('updating keyword', value);
     this.keyword = value;
   };
 

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import AgendaItem from 'frontend-burgernabije-besluitendatabank/models/mu-search/agenda-item';
+import GoverningBodyDisabledList from 'frontend-burgernabije-besluitendatabank/services/governing-body-disabled-list';
 import GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import GovernmentListService from 'frontend-burgernabije-besluitendatabank/services/government-list';
 
@@ -20,6 +21,7 @@ import { cleanString } from 'frontend-burgernabije-besluitendatabank/utils/clean
 import {
   parseMuSearchAttributeToDate,
   parseMuSearchAttributeToString,
+  parseMuSearchAttributeToArray,
 } from 'frontend-burgernabije-besluitendatabank/utils/mu-search-data-format';
 
 interface AgendaItemsParams {
@@ -45,6 +47,7 @@ class AgendaItemsLoader extends Resource<AgendaItemsLoaderArgs> {
   @service declare governingBodyList: GoverningBodyListService;
   @service declare governmentList: GovernmentListService;
   @service declare muSearch: MuSearchService;
+  @service declare governingBodyDisabledList: GoverningBodyDisabledList;
 
   @tracked data: AgendaItem[] = [];
   @tracked total = 0;
@@ -119,8 +122,19 @@ class AgendaItemsLoader extends Resource<AgendaItemsLoaderArgs> {
           })
         );
 
+      // remove disabled governing bodies from the response
+      const items = agendaItems.items.filter((item) => {
+        console.log(
+          'item.governingBodyClassificationName',
+          item.governingBodyClassificationName
+        );
+        return !this.governingBodyDisabledList.disabledList.some((disabled) =>
+          item.governingBodyIdResolved.includes(disabled)
+        );
+      });
+
       this.total = agendaItems.count ?? 0;
-      this.data = [...this.data, ...agendaItems.items.slice()];
+      this.data = [...this.data, ...items.slice()];
     }
   );
 
@@ -277,6 +291,8 @@ type AgendaItemMuSearchEntry = {
   location_id?: string;
   abstract_governing_body_location_name?: string;
   governing_body_location_name?: string;
+  abstract_governing_body_id?: string;
+  governing_body_id?: string;
   abstract_governing_body_name?: string;
   governing_body_name?: string;
   abstract_governing_body_classification_name?: string;
@@ -374,6 +390,12 @@ const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (
     parseMuSearchAttributeToString(entry.abstract_governing_body_location_name);
   dataResponse.governingBodyLocationName = parseMuSearchAttributeToString(
     entry.governing_body_location_name
+  );
+  dataResponse.abstractGoverningBodyId = parseMuSearchAttributeToArray(
+    entry.abstract_governing_body_id
+  );
+  dataResponse.governingBodyId = parseMuSearchAttributeToArray(
+    entry.governing_body_id
   );
   dataResponse.abstractGoverningBodyName = parseMuSearchAttributeToString(
     entry.abstract_governing_body_name

--- a/app/models/agenda-item.ts
+++ b/app/models/agenda-item.ts
@@ -47,6 +47,10 @@ export default class AgendaItemModel extends Model {
     return this.session?.municipality;
   }
 
+  get governingBodyIdResolved() {
+    return this.session?.governingBodyResolved?.id;
+  }
+
   get governingBodyNameResolved() {
     return this.session?.governingBodyNameResolved;
   }

--- a/app/models/mu-search/agenda-item.ts
+++ b/app/models/mu-search/agenda-item.ts
@@ -6,6 +6,8 @@ export default class AgendaItemModel {
   declare locationId?: string;
   declare abstractGoverningBodyLocationName?: string;
   declare governingBodyLocationName?: string;
+  declare abstractGoverningBodyId: string[];
+  declare governingBodyId: string[];
   declare abstractGoverningBodyName?: string;
   declare governingBodyName?: string;
   declare abstractGoverningBodyClassificationName?: string;
@@ -33,6 +35,10 @@ export default class AgendaItemModel {
       this.governingBodyClassificationName ||
       'Ontbrekend bestuursorgaan'
     );
+  }
+
+  get governingBodyIdResolved() {
+    return [...this.governingBodyId, ...this.abstractGoverningBodyId];
   }
 
   get titleResolved() {

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -2,12 +2,15 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import type PlausibleService from 'ember-plausible/services/plausible';
 import config from 'frontend-burgernabije-besluitendatabank/config/environment';
+import GoverningBodyDisabledList from 'frontend-burgernabije-besluitendatabank/services/governing-body-disabled-list';
 
 export default class ApplicationRoute extends Route {
   @service declare plausible: PlausibleService;
+  @service declare governingBodyDisabledList: GoverningBodyDisabledList;
 
   beforeModel(): void {
     this.startAnalytics();
+    this.setGoverningBodyDisabledList();
   }
 
   startAnalytics(): void {
@@ -19,5 +22,13 @@ export default class ApplicationRoute extends Route {
         apiHost,
       });
     }
+  }
+
+  setGoverningBodyDisabledList(): void {
+    this.governingBodyDisabledList.disabledList = !config[
+      'governing-body-disabled'
+    ].startsWith('{{')
+      ? config['governing-body-disabled'].split(',')
+      : [];
   }
 }

--- a/app/services/governing-body-disabled-list.ts
+++ b/app/services/governing-body-disabled-list.ts
@@ -1,0 +1,23 @@
+import Service from '@ember/service';
+
+export default class GoverningBodyDisabledList extends Service {
+  list: Array<string> = [];
+
+  get disabledList(): Array<string> {
+    return this.list;
+  }
+
+  set disabledList(value: Array<string>) {
+    this.list = value;
+  }
+}
+
+// Don't remove this declaration: this is what enables TypeScript to resolve
+// this service using `Owner.lookup('service:government-list')`, as well
+// as to check when you pass the service name as an argument to the decorator,
+// like `@service('government-list') declare altName: GovernmentListService;`.
+declare module '@ember/service' {
+  interface Registry {
+    'governing-body-disabled-list': GoverningBodyDisabledList;
+  }
+}

--- a/app/utils/mu-search-data-format.ts
+++ b/app/utils/mu-search-data-format.ts
@@ -37,3 +37,19 @@ export const parseMuSearchAttributeToString = (
 
   return input;
 };
+
+export const parseMuSearchAttributeToArray = (
+  input: string | string[] | undefined
+): string[] => {
+  // Check if input is undefined or an empty array
+  if (!input || (Array.isArray(input) && input.length === 0)) {
+    return [];
+  }
+
+  // Always take the first element if input is an array
+  if (Array.isArray(input)) {
+    return input;
+  }
+
+  return [input];
+};

--- a/config/environment.js
+++ b/config/environment.js
@@ -24,6 +24,7 @@ module.exports = function (environment) {
       // define feature flags here
       'statistics-page-feature': false,
     },
+    'governing-body-disabled': '{{GOVERNING_BODY_DISABLED_LIST}}',
   };
 
   if (environment === 'test') {


### PR DESCRIPTION
Related to BNB-617

Add a way to disable governing bodies through environment variable. 

Agenda-item linked to disabled governing body are not visible on the list page, and detail page are redirected to the list page. 