### PR TITLE
New helper to show document type of the sources

### DIFF
--- a/app/helpers/document-type.ts
+++ b/app/helpers/document-type.ts
@@ -1,0 +1,19 @@
+import { helper } from '@ember/component/helper';
+
+type DocumentTypeArgs = [string];
+
+export default helper(function documentType([url]: DocumentTypeArgs): string {
+  if (typeof url !== 'string') {
+    return 'Onbekend Type';
+  }
+
+  if (url.includes('agenda')) {
+    return 'Agenda';
+  } else if (url.includes('besluitenlijst') || url.includes('besluit')) {
+    return 'Besluitenlijst';
+  } else if (url.includes('notulen') || url.includes('notule')) {
+    return 'Notule';
+  } else {
+    return 'Onbekend Type';
+  }
+});

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -223,6 +223,8 @@
                           href={{alternateLink}}
                           class="au-u-flex--inline"
                         >
+                          <AuPill>{{document-type alternateLink}}</AuPill>
+                          -
                           {{alternateLink}}
                         </AuLinkExternal>
                       {{/if}}

--- a/tests/integration/helpers/document-type-test.js
+++ b/tests/integration/helpers/document-type-test.js
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | document-type', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns "Agenda" when URL contains "agenda"', async function (assert) {
+    this.set('content', 'https://example.com/agenda/123');
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Agenda',
+      'Returns Agenda for a URL containing "agenda"',
+    );
+  });
+
+  test('it returns "Besluitenlijst" when URL contains "besluitenlijst"', async function (assert) {
+    this.set('content', 'https://example.com/besluitenlijst/456');
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Besluitenlijst',
+      'Returns Besluitenlijst for a URL containing "besluitenlijst"',
+    );
+  });
+
+  test('it returns "Besluitenlijst" when URL contains "besluit"', async function (assert) {
+    this.set('content', 'https://example.com/besluit/789');
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Besluitenlijst',
+      'Returns Besluitenlijst for a URL containing "besluit"',
+    );
+  });
+
+  test('it returns "Notule" when URL contains "notulen"', async function (assert) {
+    this.set('content', 'https://example.com/notulen/101112');
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Notule',
+      'Returns Notule for a URL containing "notulen"',
+    );
+  });
+
+  test('it returns "Notule" when URL contains "notule"', async function (assert) {
+    this.set('content', 'https://example.com/notule/131415');
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Notule',
+      'Returns Notule for a URL containing "notule"',
+    );
+  });
+
+  test('it returns "Onbekend Type" when URL does not contain known types', async function (assert) {
+    this.set('content', 'https://example.com/other/xyz');
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Onbekend Type',
+      'Returns Onbekend Type when no known type is found',
+    );
+  });
+
+  test('it returns "Onbekend Type" when URL is not a string', async function (assert) {
+    this.set('content', 12345);
+    await render(hbs`{{document-type this.content}}`);
+
+    assert.strictEqual(
+      this.element.textContent?.trim(),
+      'Onbekend Type',
+      'Returns Onbekend Type when the input is not a string',
+    );
+  });
+});


### PR DESCRIPTION
Show document type of the sources on the detail page

Currently, on the detail page of an agenda item in the "Lokaal Beslist" app, the various sources for the agenda item are displayed as URLs. To improve usability, we want to enhance this by also displaying a label that indicates the document type of the source.

The document type can be determined from the URL of the source. Possible types include: agenda, notule, and besluitenlijst.

Acceptance Criteria:

Each source URL on the agenda item detail page should display a label indicating the document type (e.g., "Agenda", "Notule", or "Besluitenlijst").

The document type should be dynamically extracted from the URL.

If the document type cannot be determined, a default label such as "Onbekend Type" should be displayed.

The layout of the agenda item detail page should remain user-friendly and visually clear after the addition of the document type labels.

Technical Details:

Update the logic that processes the source URLs to parse and extract the document type (e.g., URLs containing keywords such as agenda, notule, or besluitenlijst).

Map these keywords to human-readable labels:

agenda → "Agenda"

notule → "Notule"

besluitenlijst → "Besluitenlijst"


This can be tested by running the frontend:
ember s --proxy https://lokaalbeslist.lblod.info/