### PR TITLE
Feature/bnb 316 add nog niet behandeld explanations

### DIFF
--- a/app/components/vote-overview.ts
+++ b/app/components/vote-overview.ts
@@ -32,11 +32,15 @@ export default class VoteOverview extends Component<ArgsInterface> {
   }
 
   get hasVotersData() {
-    return (
-      this.args.vote.hasAbstainers.slice().length > 0 ||
-      this.args.vote.hasOpponents.slice().length > 0 ||
-      this.args.vote.hasProponents.slice().length > 0
-    );
+    const abstainers = this.args.vote.hasAbstainers;
+    const opponents = this.args.vote.hasOpponents;
+    const proponents = this.args.vote.hasProponents;
+
+    const hasAbstainers = Array.isArray(abstainers) && abstainers.length > 0;
+    const hasOpponents = Array.isArray(opponents) && opponents.length > 0;
+    const hasProponents = Array.isArray(proponents) && proponents.length > 0;
+
+    return hasAbstainers || hasOpponents || hasProponents;
   }
 
   get numberOfAbstentions() {

--- a/app/controllers/agenda-items/agenda-item.ts
+++ b/app/controllers/agenda-items/agenda-item.ts
@@ -4,6 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import type AgendaItemRoute from 'frontend-burgernabije-besluitendatabank/routes/agenda-items/agenda-item';
 import type KeywordStoreService from 'frontend-burgernabije-besluitendatabank/services/keyword-store';
 import type { ModelFrom } from '../../lib/type-utils';
+import type ResolutionModel from 'frontend-burgernabije-besluitendatabank/models/resolution';
+import type ArrayProxy from '@ember/array/proxy';
 
 export default class AgendaItemController extends Controller {
   @service declare keywordStore: KeywordStoreService;
@@ -14,6 +16,12 @@ export default class AgendaItemController extends Controller {
 
   get hasArticles() {
     return !!this.model.articles?.length;
+  }
+
+  get firstResolution() {
+    return (
+      this.model.resolutions as ArrayProxy<ResolutionModel>[] | undefined
+    )?.[0];
   }
 
   get municipalityQuery() {

--- a/app/routes/agenda-items/agenda-item.ts
+++ b/app/routes/agenda-items/agenda-item.ts
@@ -102,8 +102,8 @@ export default class AgendaItemRoute extends Route {
     )
       .filter((item) => item.id !== agendaItem.id && !!item.title)
       .slice(0, 4);
-
     return {
+      resolutions,
       agendaItem,
       vote,
       articles,

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -93,12 +93,7 @@
                 @iconClosed="nav-right"
                 @buttonLabel="Besluit"
               >
-                {{#let
-                  (get
-                    this.model.agendaItem.handledBy.resolutions "firstObject"
-                  )
-                  as |resolution|
-                }}
+                {{#let this.firstResolution as |resolution|}}
                   {{#if resolution.value}}
                     <AuAlert
                       @skin="success"

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -122,7 +122,13 @@
                       @skin="warning"
                       @title="Besluit niet beschikbaar"
                       class="au-u-margin-top au-u-margin-bottom"
-                    />
+                    >
+                      {{#if this.model.agendaItem.wasHandled}}
+                        <p>De data voor dit agendapunt is nog niet beschikbaar.</p>
+                      {{else}}
+                        <p>Dit agendapunt werd nog niet behandeld.</p>
+                      {{/if}}
+                    </AuAlert>
                   {{/if}}
                   {{#if resolution.motivation}}
                     <div class="c-accordion-holder c-accordion-holder--top">
@@ -185,7 +191,13 @@
                     @skin="warning"
                     @title="Stemming niet beschikbaar"
                     class="au-u-margin-top au-u-margin-bottom"
-                  />
+                  >
+                    {{#if this.model.agendaItem.wasHandled}}
+                      <p>De data voor dit agendapunt is nog niet beschikbaar.</p>
+                    {{else}}
+                      <p>Dit agendapunt werd nog niet behandeld.</p>
+                    {{/if}}
+                  </AuAlert>
                 {{/if}}
               </AuAccordion>
             </section>


### PR DESCRIPTION
Add `nog niet behandeld` explanations

Currently, when the data for a decision or vote is unavailable on the agenda detail page, we display a generic "Data niet beschikbaar" message. This message does not provide sufficient context to the user, as there are multiple reasons why the decision or vote data might not be available (e.g., data not harvested yet, or the agenda item has not yet been handled).

We want to improve the user experience by replacing the generic message with a contextual alert-card that includes a specific title and explanatory body text based on the reason for the missing data.

Acceptance Criteria:

Replace the current "Data niet beschikbaar" message with an alert-card component.

The alert-card should display different titles and body text based on the specific reason for the missing data:

Case 1: Data not harvested yet

Title: Besluit/Stemming Niet Beschikbaar

Body: De data voor dit agendapunt is nog niet beschikbaar.

Case 2: Agenda item not yet handled

Title: Besluit/Stemming Niet Beschikbaar

Body: Dit agendapunt werd nog niet behandeld.

The logic to determine the reason should be based on the status of the agenda point (e.g., harvested status, handled status).

Test Scenario:

When the data for an agenda point is not harvested,
If the detail page is loaded,
Then the alert-card should display:

Title: Besluit/Stemming Niet Beschikbaar

Body: De data voor dit agendapunt is nog niet beschikbaar.

When the agenda point has not been handled yet,
If the detail page is loaded,
Then the alert-card should display:

Title: Besluit/Stemming Niet Beschikbaar

Body: Dit agendapunt werd nog niet behandeld.

When the decision or vote data is available for an agenda point,
If the detail page is loaded,
Then the alert-card should not be displayed.


This can be tested by running the frontend:
`ember s --proxy https://lokaalbeslist.lblod.info/`

