### PR TITLE
New helper function to format number

### DIFF
--- a/app/helpers/format-number.ts
+++ b/app/helpers/format-number.ts
@@ -1,0 +1,21 @@
+import { helper } from '@ember/component/helper';
+
+export function formatNumber([value, decimalPlaces = 2]: [
+  string | number,
+  number?,
+]): string {
+  if (typeof value === 'string') {
+    value = parseFloat(value.replace(/,/g, ''));
+  }
+
+  if (isNaN(value)) {
+    return 'Invalid number';
+  }
+
+  return value.toLocaleString('de-DE', {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  });
+}
+
+export default helper(formatNumber);

--- a/app/templates/agenda-items/index.hbs
+++ b/app/templates/agenda-items/index.hbs
@@ -74,7 +74,7 @@
                   <p
                     class="au-u-margin-left au-u-margin-top-small au-u-h4 au-u-medium"
                   >
-                    {{loader.total}}
+                    {{format-number loader.total 0}}
                     {{#if (eq loader.total 1)}}
                       Zoekresultaat
                     {{else}}

--- a/tests/integration/helpers/format-number-test.ts
+++ b/tests/integration/helpers/format-number-test.ts
@@ -1,0 +1,64 @@
+import { formatNumber } from 'frontend-burgernabije-besluitendatabank/helpers/format-number';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | format-number', function () {
+  test('it formats whole numbers correctly', function (assert) {
+    assert.strictEqual(
+      formatNumber([3118248]),
+      '3.118.248,00',
+      'Formats large numbers with dot separators and two decimals',
+    );
+  });
+
+  test('it formats numbers with decimals', function (assert) {
+    assert.strictEqual(
+      formatNumber([1000.5]),
+      '1.000,50',
+      'Formats decimals correctly',
+    );
+    assert.strictEqual(
+      formatNumber([1234.567, 3]),
+      '1.234,567',
+      'Handles custom decimal places',
+    );
+    assert.strictEqual(
+      formatNumber([1234.567, 1]),
+      '1.234,6',
+      'Rounds correctly to 1 decimal place',
+    );
+  });
+
+  test('it handles string inputs with commas', function (assert) {
+    assert.strictEqual(
+      formatNumber(['3,118,248']),
+      '3.118.248,00',
+      'Handles string input with commas',
+    );
+    assert.strictEqual(
+      formatNumber(['1,234.567']),
+      '1.234,57',
+      'Handles decimal string input with commas',
+    );
+  });
+
+  test('it handles invalid inputs', function (assert) {
+    assert.strictEqual(
+      formatNumber(['abc']),
+      'Invalid number',
+      'Returns "Invalid number" for non-numeric values',
+    );
+    assert.strictEqual(
+      formatNumber(['']),
+      'Invalid number',
+      'Handles empty strings correctly',
+    );
+  });
+
+  test('it formats numbers with zero decimal places', function (assert) {
+    assert.strictEqual(
+      formatNumber([5000, 0]),
+      '5.000',
+      'Formats number with zero decimal places',
+    );
+  });
+});


### PR DESCRIPTION
Formats large numbers with dot separators for example: `3118248` should be shown as `3.118.248
`Tests have been written for this in  `format-number-test.ts`