### PR TITLE
Refactor filter sidebar to include province labels and fix classification model naming

### DIFF
--- a/app/components/filter-sidebar-wrapper.ts
+++ b/app/components/filter-sidebar-wrapper.ts
@@ -11,7 +11,7 @@ import type {
   SortType,
 } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
 import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
-import type { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
+import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 
 interface FilterSidebarWrapperArgs {
   filters: AgendaItemsParams;
@@ -51,7 +51,7 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
   }
 
   @action
-  updateSelectedGovernment(
+  async updateSelectedGovernment(
     newOptions: Array<{
       label: string;
       id: string;
@@ -59,11 +59,20 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
     }>,
   ) {
     this.governmentList.selected = newOptions;
-    this.governingBodyList.selected = [];
-    const municipalityLabels = newOptions.map((o) => o.label).toString();
+    const municipalityLabels = newOptions
+      .filter((o) => o.type === LocalGovernmentType.Municipality)
+      .map((o) => o.label)
+      .toString();
+    const provinceLabels = newOptions
+      .filter((o) => o.type === LocalGovernmentType.Province)
+      .map((o) => o.label)
+      .toString();
     this.filterService.updateFilters({
       municipalityLabels,
+      provinceLabels,
     });
+
+    await this.governingBodyList.loadOptions();
   }
   get selectedMunicipality() {
     return this.filterService.filters.municipalityLabels;

--- a/app/models/administrative-unit-classification-code.ts
+++ b/app/models/administrative-unit-classification-code.ts
@@ -1,11 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 
-export default class AdministrativeUnitClasssificationCodeModel extends Model {
+export default class AdministrativeUnitClassificationCodeModel extends Model {
   @attr('string') declare label: string;
 }
 
 declare module 'ember-data/types/registries/model' {
   export default interface ModelRegistry {
-    'administrative-unit-classification-code': AdministrativeUnitClasssificationCodeModel;
+    'administrative-unit-classification-code': AdministrativeUnitClassificationCodeModel;
   }
 }

--- a/app/models/administrative-unit.ts
+++ b/app/models/administrative-unit.ts
@@ -1,6 +1,6 @@
 import type { AsyncBelongsTo, AsyncHasMany } from '@ember-data/model';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import type AdministrativeUnitClasssificationCodeModel from './administrative-unit-classification-code';
+import type AdministrativeUnitClassificationCodeModel from './administrative-unit-classification-code';
 import type GoverningBodyModel from './governing-body';
 import type LocationModel from './location';
 
@@ -15,7 +15,7 @@ export default class AdministrativeUnitModel extends Model {
     async: true,
     inverse: null,
   })
-  declare classification: AsyncBelongsTo<AdministrativeUnitClasssificationCodeModel>;
+  declare classification: AsyncBelongsTo<AdministrativeUnitClassificationCodeModel>;
 
   @belongsTo('location', { async: true, inverse: null })
   declare location: AsyncBelongsTo<LocationModel>;


### PR DESCRIPTION
## Issue
When the user has selected a local government; then the selection for filter ‘Bestuursorganen’ shows all options until one is selected.

## Expected
The options listed for filter ‘Bestuursorganen’ should only show relevant options once the local government is selected; it should not be needed to select an invalid option first before only the relevant options get displayed.

## Test
Run `ember s --proxy https://lokaalbeslist.vlaanderen.be/`
