### PR TITLE
Bugfix: Refactor keyword query formatting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
+## v0.8.7 (2025-04-18)
+
+#### :rocket: Enhancement
+
+- [#226](https://github.com/lblod/frontend-burgernabije-besluitendatabank/pull/227) Hotfix: Refactor keyword query formatting by ([@Andresdev02](https://github.com/Andresdev02))
+
+#### Committers: 1
+
+- Andres Vergauwen ([@Andresdev02](https://github.com/Andresdev02))
+
 ## v0.8.6 (2025-03-20)
 
 #### :rocket: Enhancement
 
-- [#226](https://github.com/lblod/frontend-burgernabije-besluitendatabank/pull/226) Hotfix void error on search by ([@madnificent](https://github.com/Andresdev02))
+- [#226](https://github.com/lblod/frontend-burgernabije-besluitendatabank/pull/226) Hotfix void error on search by ([@Andresdev02](https://github.com/Andresdev02))
 
 #### Committers: 1
 

--- a/app/helpers/keyword-search.ts
+++ b/app/helpers/keyword-search.ts
@@ -57,10 +57,18 @@ function getKeywordAdvancedSearch(
 
 function formatQueryToParts(query: string, operators: string[]): string[] {
   const formattedQuery = query
-    .replace(/-\w+/g, (match) => 'NOT ' + match.slice(1))
-    .replace(/EN/g, 'SKIP')
-    .replace(/OF/g, 'OR')
-    .replace(/"([^"]+)"/g, (match, p1) => `MUST ${p1}`)
+    .split(/(".*?")/g)
+    .map((part) => {
+      if (part.startsWith('"') && part.endsWith('"')) {
+        return `MUST ${part.slice(1, -1)}`;
+      } else {
+        return part
+          .replace(/-\w+/g, (match) => 'NOT ' + match.slice(1))
+          .replace(/EN/g, 'SKIP')
+          .replace(/OF/g, 'OR');
+      }
+    })
+    .join('')
     .trim();
 
   if (
@@ -70,7 +78,6 @@ function formatQueryToParts(query: string, operators: string[]): string[] {
   ) {
     return [];
   }
-
   return formattedQuery.split(/ (SKIP) /);
 }
 

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -75,7 +75,7 @@
               </li>
             </ul>
             <AuContent @skin="small">
-              <p class="au-u-muted">
+              <p class="au-u-muted au-u-word-break">
                 {{#if this.model.agendaItem.description}}
                   {{this.model.agendaItem.description}}
                 {{else}}
@@ -133,7 +133,7 @@
                         @buttonLabel="Motivering"
                       >
                         <AuContent @skin="small" class="au-u-padding">
-                          <p class="au-u-muted">
+                          <p class="au-u-muted au-u-word-break">
                             {{resolution.motivation}}
                           </p>
                         </AuContent>
@@ -331,29 +331,32 @@
               {{/if}}
             {{/if}}
             {{#if (is-pending this.model.similarAgendaItemsPromise)}}
-                <AuHeading @level="2" @skin="4">
-                  {{#if this.keywordStore.keyword}}
-                    Meer relevante info over
-                    <AuLink
-                      class="au-u-medium"
-                    >{{this.keywordStore.keyword}}</AuLink>
-                  {{else}}
-                    Meer agendapunten
-                  {{/if}}
-                  in
+              <AuHeading @level="2" @skin="4">
+                {{#if this.keywordStore.keyword}}
+                  Meer relevante info over
                   <AuLink
-                    @route="agenda-items"
-                    @query={{this.municipalityQuery}}
                     class="au-u-medium"
-                  >{{this.model.agendaItem.session.municipality}}</AuLink>
-                  worden geladen...
-                </AuHeading>
+                  >{{this.keywordStore.keyword}}</AuLink>
+                {{else}}
+                  Meer agendapunten
+                {{/if}}
+                in
+                <AuLink
+                  @route="agenda-items"
+                  @query={{this.municipalityQuery}}
+                  class="au-u-medium"
+                >{{this.model.agendaItem.session.municipality}}</AuLink>
+                worden geladen...
+              </AuHeading>
             {{else}}
-              {{#let (await this.model.similarAgendaItemsPromise) as |similarAgendaItems|}}
+              {{#let
+                (await this.model.similarAgendaItemsPromise)
+                as |similarAgendaItems|
+              }}
                 {{#if
                   (and
-                     this.model.agendaItem.session.hasMunicipality
-                     similarAgendaItems.length
+                    this.model.agendaItem.session.hasMunicipality
+                    similarAgendaItems.length
                   )
                 }}
                   <AuHeading @level="2" @skin="4">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-burgernabije-besluitendatabank",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "description": "The front-end for BNB, a site that uses linked data to empower everyone in Flanders to consult the decisions made by their local authorities.",
   "repository": {


### PR DESCRIPTION
The search function on the Lokaal Beslist website seems to have an issue when processing exact search queries with quotation marks. When searching for "Vlaio-2022-19", I expect the search function to search for the exact string, but it is being interpreted incorrectly.

Instead of searching for "Vlaio-2022-19" exactly, the function only searches for "Vlaio" and treats "-2022" and "-19" as words to be excluded. This is contrary to the expected behavior, as the quotation marks should match the search term exactly.

Steps to reproduce the issue:

Go to the search page: [link to the search page](https://lokaalbeslist.vlaanderen.be/agendapunten?provincies=Vlaams-Brabant&trefwoord=%22Vlaio-2022-19%22).

Enter the search term "Vlaio-2022-19" in the search bar.

Click 'Search'.

Current behavior: The search function interprets the query as "Vlaio", excluding the terms "-2022" and "-19", despite them being inside quotation marks.

Expected behavior: The search function should search exactly for the term "Vlaio-2022-19" without excluding "-2022" and "-19".

Link to the bug: https://lokaalbeslist.vlaanderen.be/agendapunten?provincies=Vlaams-Brabant&trefwoord=%22Vlaio-2022-19%22


Can be tested locally here: `ember s --proxy https://lokaalbeslist.vlaanderen.be/ `
And online here: [Lokaalbeslist](https://mbp.lokaalbeslist.lblod.info/?trefwoord=%22Vlaio-2022-19%22)