### PR TITLE
Fix: Add optional chaining to prevent potential null reference errors

### DIFF
--- a/app/routes/sessions/session.ts
+++ b/app/routes/sessions/session.ts
@@ -26,11 +26,11 @@ export default class SessionRoute extends Route {
         'agenda-items.handled-by.resolutions',
       ].join(','),
     });
-    const agendaItems = await session.get('agendaItems');
-    const govBody = await session.get('governingBody');
+    const agendaItems = await session?.get('agendaItems');
+    const govBody = await session?.get('governingBody');
     const resolvedGovBody = await govBody?.get('isTimeSpecializationOf');
     const governingBody = resolvedGovBody ?? govBody;
-    const classification = await governingBody.get('classification');
+    const classification = await governingBody?.get('classification');
     return {
       session,
       agendaItems: this.loadAgendaItemsTask.perform(
@@ -39,7 +39,7 @@ export default class SessionRoute extends Route {
       ),
       otherSessions: this.loadOtherSessionsTask.perform(governingBody, session),
       governingBodies: this.loadGoverningBodiesTask.perform(governingBody),
-      classificationLabel: classification.get('label'),
+      classificationLabel: classification?.get('label'),
     };
   }
 
@@ -136,7 +136,7 @@ function getUniqueGoverningBodies(
   return governingBodies
     .reduce(
       (unique, govBody) => {
-        const label = govBody.get('classification').get('label');
+        const label = govBody?.get('classification')?.get('label');
         if (label && !uniqueLabels.has(label)) {
           uniqueLabels.add(label);
           unique.push({ label });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.7",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-burgernabije-besluitendatabank",
-      "version": "0.8.7",
+      "version": "0.8.9",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.7",
+  "version": "0.8.9",
   "private": true,
   "description": "The front-end for BNB, a site that uses linked data to empower everyone in Flanders to consult the decisions made by their local authorities.",
   "repository": {


### PR DESCRIPTION
This should resolve the issue when you go to a session page of Gent for example. 
https://lokaalbeslist.vlaanderen.be/zittingen/7738a693-e5aa-5a07-b7a6-2f65a43c1be1