### PR TITLE
Feature/fix missing gov bodies

### DIFF
--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -62,6 +62,7 @@
           @id="governing-body"
           @label="Kies één of meer bestuursorganen"
           @options={{this.governigBodyOptions}}
+          @loading={{this.governingBodyList.isLoading}}
           @selected={{this.governingBodyList.selected}}
           @updateSelected={{this.updateSelectedGoverningBodyClassifications}}
           @noMatchesMessage="Geen bestuursorganen gevonden"

--- a/app/components/filters/select-multiple-filter.hbs
+++ b/app/components/filters/select-multiple-filter.hbs
@@ -4,7 +4,10 @@
     {{!template-lint-disable no-duplicate-id}}
     id={{@id}}
     @onChange={{this.selectChange}}
-    class="au-u-1-1"
+    class="au-u-1-1{{if @loading ' u-select--loading'}}"
+    data-test-select-multiple-filter-loading={{@loading}}
+    @disabled={{@loading}}
+    @loadingMessage="Aan het laden..."
     @selected={{this.selected}}
     @options={{@options}}
     @allowClear={{true}}

--- a/app/components/filters/select-multiple-filter.ts
+++ b/app/components/filters/select-multiple-filter.ts
@@ -18,6 +18,7 @@ interface Signature {
     options: Promise<UnifiedOptions[]>;
     selected: Option[];
     updateSelected: (selected: Option[]) => void;
+    loading?: boolean;
   } & FilterArgs;
 }
 

--- a/app/models/governing-body.ts
+++ b/app/models/governing-body.ts
@@ -41,6 +41,15 @@ export default class GoverningBodyModel extends Model {
   })
   declare classification: AsyncBelongsTo<GoverningBodyClasssificationCodeModel>;
 
+  /**
+   * Fallback classification linked through `org:classification` instead of `besluit:classificatie`.
+   */
+  @belongsTo('governing-body-classification-code', {
+    async: true,
+    inverse: null,
+  })
+  declare orgClassification: AsyncBelongsTo<GoverningBodyClasssificationCodeModel>;
+
   @hasMany('session', { async: true, inverse: 'governingBody' })
   declare sessions: AsyncHasMany<SessionModel>;
 

--- a/app/services/governing-body-list.ts
+++ b/app/services/governing-body-list.ts
@@ -10,6 +10,7 @@ import type { AdapterPopulatedRecordArrayWithMeta } from 'frontend-burgernabije-
 import type GovernmentListService from './government-list';
 import type FilterService from './filter-service';
 import type ProvinceListService from './province-list';
+import type MuSearchService from './mu-search';
 import type GoverningBodyClassificationCodeModel from 'frontend-burgernabije-besluitendatabank/models/governing-body-classification-code';
 
 export type GoverningBodyOption = {
@@ -30,9 +31,15 @@ export default class GoverningBodyListService extends Service {
   @service declare provinceList: ProvinceListService;
   @service declare governmentList: GovernmentListService;
   @service declare filterService: FilterService;
+  @service declare muSearch: MuSearchService;
 
   @tracked selected: GoverningBodyOption[] = [];
   @tracked options: GoverningBodyOption[] = [];
+  @tracked isLoading = false;
+
+  private locationOptionsCacheKey?: string;
+  private locationOptionsCache?: GoverningBodyOption[];
+  private loadToken = 0;
 
   constructor(...args: []) {
     super(...args);
@@ -70,72 +77,138 @@ export default class GoverningBodyListService extends Service {
   }
 
   async loadOptions(): Promise<GoverningBodyOption[]> {
-    const { municipalityLabels, governingBodyClassifications, provinceLabels } =
-      this.filterService.filters;
+    const token = ++this.loadToken;
 
-    const hasLocationFilters =
-      Boolean(municipalityLabels?.trim()) || Boolean(provinceLabels?.trim());
+    try {
+      const {
+        municipalityLabels,
+        governingBodyClassifications,
+        provinceLabels,
+      } = this.filterService.filters;
 
-    if (!hasLocationFilters) {
-      const allCodes = await this.store.query(
-        'governing-body-classification-code',
-        {
+      const hasLocationFilters =
+        Boolean(municipalityLabels?.trim()) || Boolean(provinceLabels?.trim());
+
+      if (!hasLocationFilters) {
+        const allCodes = await this.store.query(
+          'governing-body-classification-code',
+          {
+            page: { size: 999 },
+            sort: 'label',
+          },
+        );
+
+        if (token !== this.loadToken) return this.options;
+
+        this.options = this.sortOptions(
+          this.getUniqueClassifications(allCodes),
+        );
+
+        this.restoreSelected(governingBodyClassifications);
+        return this.options;
+      }
+
+      const locationCacheKey = `${municipalityLabels ?? ''}|${provinceLabels ?? ''}`;
+      if (
+        this.locationOptionsCacheKey === locationCacheKey &&
+        this.locationOptionsCache
+      ) {
+        this.options = this.locationOptionsCache;
+        this.restoreSelected(governingBodyClassifications);
+        return this.options;
+      }
+
+      this.isLoading = true;
+
+      const [municipalityIds, provinceIds] = await Promise.all([
+        municipalityLabels
+          ? this.municipalityList.getLocationIdsFromLabels(
+              municipalityLabels.replace(',', '+'),
+            )
+          : Promise.resolve([]),
+        provinceLabels
+          ? this.provinceList.getProvinceIdsFromLabels(
+              provinceLabels.replace(',', '+'),
+            )
+          : Promise.resolve([]),
+      ]);
+
+      const locationIds = [...municipalityIds, ...provinceIds];
+
+      const [governingBodies, allCodes] = await Promise.all([
+        this.store.query('governing-body', {
+          filter: {
+            'administrative-unit': {
+              location: { ':id:': locationIds.join(',') },
+            },
+          },
+          include: 'classification,org-classification',
+          page: { size: 999 },
+        }),
+        this.store.query('governing-body-classification-code', {
           page: { size: 999 },
           sort: 'label',
-        },
+        }),
+      ]);
+
+      // Process data
+      const bodyOptions = this.getUniqueGoverningBodies(governingBodies);
+      const filteredCodes = this.filterByLabel(allCodes, bodyOptions);
+      const uniqueCodes = this.uniqueByLabel(filteredCodes);
+
+      const candidateOptions = uniqueCodes.map((item) => ({
+        id: item.id,
+        label: item.label,
+        type: QueryParameterKeys.governingBodies,
+      }));
+
+      // Only keep bestuursorganen that actually have sessions
+      const options = await this.filterOptionsWithSessions(
+        candidateOptions,
+        locationIds,
       );
 
-      this.options = this.sortOptions(this.getUniqueClassifications(allCodes));
+      // A newer load (e.g. another municipality) superseded us; don't overwrite
+      // its results or cache with our stale ones.
+      if (token !== this.loadToken) return this.options;
+
+      this.options = options;
+      this.locationOptionsCacheKey = locationCacheKey;
+      this.locationOptionsCache = options;
 
       this.restoreSelected(governingBodyClassifications);
+
       return this.options;
+    } finally {
+      if (token === this.loadToken) {
+        this.isLoading = false;
+      }
+    }
+  }
+
+  /**
+   * Keeps only the classifications that have at least one session in the given location(s)
+   */
+  private async filterOptionsWithSessions(
+    options: GoverningBodyOption[],
+    locationIds: string[],
+  ): Promise<GoverningBodyOption[]> {
+    if (locationIds.length === 0) {
+      return options;
     }
 
-    const [municipalityIds, provinceIds] = await Promise.all([
-      municipalityLabels
-        ? this.municipalityList.getLocationIdsFromLabels(
-            municipalityLabels.replace(',', '+'),
-          )
-        : Promise.resolve([]),
-      provinceLabels
-        ? this.provinceList.getProvinceIdsFromLabels(
-            provinceLabels.replace(',', '+'),
-          )
-        : Promise.resolve([]),
-    ]);
-
-    const locationIds = [...municipalityIds, ...provinceIds];
-
-    const [governingBodies, allCodes] = await Promise.all([
-      this.store.query('governing-body', {
-        filter: {
-          'administrative-unit': {
-            location: { ':id:': locationIds.join(',') },
-          },
-        },
-        include: 'classification',
-        page: { size: 999 },
+    const hasSessions = await Promise.all(
+      options.map(async (option) => {
+        const count = await this.muSearch.count('sessions', {
+          ':has:search_location_id': 't',
+          ':terms:search_location_id': locationIds.join(','),
+          ':terms:search_governing_body_classification_id': option.id,
+        });
+        return count > 0;
       }),
-      this.store.query('governing-body-classification-code', {
-        page: { size: 999 },
-        sort: 'label',
-      }),
-    ]);
+    );
 
-    // Process data
-    const bodyOptions = this.getUniqueGoverningBodies(governingBodies);
-    const filteredCodes = this.filterByLabel(allCodes, bodyOptions);
-    const uniqueCodes = this.uniqueByLabel(filteredCodes);
-
-    this.options = uniqueCodes.map((item) => ({
-      id: item.id,
-      label: item.label,
-      type: QueryParameterKeys.governingBodies,
-    }));
-
-    this.restoreSelected(governingBodyClassifications);
-
-    return this.options;
+    return options.filter((_, index) => hasSessions[index]);
   }
 
   private filterByLabel(
@@ -179,18 +252,34 @@ export default class GoverningBodyListService extends Service {
 
     return govBodies
       .filter((govBody) => {
-        const label = govBody.classification.get('label') ?? govBody.name;
+        const classification = this.resolveClassification(govBody);
+        const label = classification.get('label') ?? govBody.name;
         if (label && !uniqueLabels.has(label)) {
           uniqueLabels.add(label);
           return true;
         }
         return false;
       })
-      .map((govBody) => ({
-        id: govBody.classification.get('id') ?? govBody.id,
-        label: govBody.classification.get('label') ?? govBody.name,
-        type: QueryParameterKeys.governingBodies,
-      }));
+      .map((govBody) => {
+        const classification = this.resolveClassification(govBody);
+        return {
+          id: classification.get('id') ?? govBody.id,
+          label: classification.get('label') ?? govBody.name,
+          type: QueryParameterKeys.governingBodies,
+        };
+      });
+  }
+
+  /**
+   * Returns the governing body classification, falling back to the one linked
+   * through `org:classification` when `besluit:classificatie` is missing.
+   * Some bestuursorganen only carry the former due to a data fault, and would
+   * otherwise be dropped from the options list.
+   */
+  private resolveClassification(govBody: GoverningBodyModel) {
+    return govBody.classification.get('label')
+      ? govBody.classification
+      : govBody.orgClassification;
   }
 
   getUniqueClassifications(

--- a/app/services/mu-search.ts
+++ b/app/services/mu-search.ts
@@ -81,6 +81,31 @@ export default class MuSearchService extends Service {
     }
   }
 
+  async count(
+    index: string,
+    filters?: { [key: string]: string },
+  ): Promise<number> {
+    try {
+      const params = ['page[size]=1', 'page[number]=0'];
+
+      if (filters) {
+        Object.entries(filters).forEach(([field, q]) => {
+          params.push(`filter[${field}]=${q}`);
+        });
+      }
+
+      const endpoint = `/search/${index}/search?${params.join('&')}`;
+      const response = await fetch(endpoint);
+      const json = await response.json();
+
+      return typeof json?.count === 'number' ? json.count : 0;
+    } catch (error) {
+      console.error('Error during search count:', error);
+
+      return 0;
+    }
+  }
+
   private sortOrder(sort: string): string {
     return sort.startsWith('-') ? 'desc' : 'asc';
   }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -395,3 +395,27 @@ cursor {
 .au-c-main-header__title {
   max-width: 100% !important;
 }
+
+.ember-power-select-trigger.u-select--loading {
+  .ember-power-select-status-icon {
+    background-image: none;
+
+    &::after {
+      content: "";
+      display: block;
+      position: absolute;
+      inset: 0;
+      border: 2px solid currentcolor;
+      border-right-color: transparent;
+      border-radius: 50%;
+      opacity: 0.5;
+      animation: u-select-spin 0.6s linear infinite;
+    }
+  }
+}
+
+@keyframes u-select-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.11",
+  "version": "0.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-burgernabije-besluitendatabank",
-      "version": "0.8.11",
+      "version": "0.8.10",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-burgernabije-besluitendatabank",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.11",
+  "version": "0.8.10",
   "private": true,
   "description": "The front-end for BNB, a site that uses linked data to empower everyone in Flanders to consult the decisions made by their local authorities.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-burgernabije-besluitendatabank",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "The front-end for BNB, a site that uses linked data to empower everyone in Flanders to consult the decisions made by their local authorities.",
   "repository": {


### PR DESCRIPTION
Fix missing bestuursorganen in filter bestuursorganen of Lokaal Beslist app

1. Use a fallback when `besluit#classificatie` is missing use `org#classification`.
2. Also improved the loading when changing a municipality

PR to be able to test it: https://github.com/lblod/app-burgernabije-besluitendatabank/pull/103